### PR TITLE
fix: fetch DNS public key correctly when there's multiple DKIM sig

### DIFF
--- a/src/helpers/dkim/tools.js
+++ b/src/helpers/dkim/tools.js
@@ -223,7 +223,7 @@ async function resolveDNSHTTP(name, type) {
       })
   );
   const out = await resp.json();
-  // For some DNS, the Answer response contains more than 1 elements in the array. The last element is the one containing the public key
+  // For some DNS, the Answer response here contains more than 1 element in the array. The last element is the one containing the public key
   return [out.Answer[out.Answer.length - 1].data];
 }
 

--- a/src/helpers/dkim/tools.js
+++ b/src/helpers/dkim/tools.js
@@ -223,7 +223,8 @@ async function resolveDNSHTTP(name, type) {
       })
   );
   const out = await resp.json();
-  return [out.Answer[0].data];
+  // For some DNS, the Answer response contains more than 1 elements in the array. The last element is the one containing the public key
+  return [out.Answer[out.Answer.length - 1].data];
 }
 
 // from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String


### PR DESCRIPTION
* The current Google DNS fetch script isnt compatible with emails that have >1 DKIM signatures
* In tools.js, the script previously extracted `out.Answer[0].data` which assumes that the public key is in the first element in the array
* For certain domains such as Venmo and Coinbase, there are 2 DKIMs and so 2 elements in the array response. The valid public key is in that second element
* This PR updates the logic to `out.Answer[out.Answer.length - 1].data` and got everything to work. Not sure if theres any more edge cases 
* For example this is the diff between [twitter](https://dns.google/resolve?name=dkim-201406._domainkey.twitter.com&type=TXT) fetch and [venmo](https://dns.google/resolve?name=224i4yxa5dv7c2xz3womw6peuasteono._domainkey.amazonses.com&type=TXT) or [coinbase](https://dns.google/resolve?name=5c24xsnuonrh6rsnd2gzke4plbing7ut._domainkey.mail.coinbase.com&type=TXT)