### PR TITLE
Circom improvements

### DIFF
--- a/packages/circuits/email-verifier.circom
+++ b/packages/circuits/email-verifier.circom
@@ -33,7 +33,7 @@ template EmailVerifier(max_header_bytes, max_body_bytes, n, k, ignore_body_hash_
     // The header signs the fields in the "h=Date:From:To:Subject:MIME-Version:Content-Type:Message-ID;"
     // section of the "DKIM-Signature:"" line, along with the body hash.
     // Note that nothing above the "DKIM-Signature:" line is signed.
-    signal sha[256] <== Sha256Bytes(max_header_bytes)(in_padded, in_len_padded_bytes);
+    signal output sha[256] <== Sha256Bytes(max_header_bytes)(in_padded, in_len_padded_bytes);
     var msg_len = (256 + n) \ n;
 
     component base_msg[msg_len];

--- a/packages/circuits/email-verifier.circom
+++ b/packages/circuits/email-verifier.circom
@@ -27,7 +27,6 @@ template EmailVerifier(max_header_bytes, max_body_bytes, n, k, ignore_body_hash_
 
     // Base 64 body hash variables
     var LEN_SHA_B64 = 44;     // ceil(32 / 3) * 4, due to base64 encoding.
-    signal input body_hash_idx;
 
     // SHA HEADER: 506,670 constraints
     // This calculates the SHA256 hash of the header, which is the "base_msg" that is RSA signed.
@@ -62,6 +61,8 @@ template EmailVerifier(max_header_bytes, max_body_bytes, n, k, ignore_body_hash_
 
 
     if (ignore_body_hash_check != 1) {
+        signal input body_hash_idx;
+
         // BODY HASH REGEX: 617,597 constraints
         // This extracts the body hash from the header (i.e. the part after bh= within the DKIM-signature section)
         // which is used to verify the body text matches this signed hash + the signature verifies this hash is legit

--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zk-email/circuits",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "scripts": {
     "publish": "yarn npm publish --access=public",
     "test": "jest tests/*.ts"

--- a/packages/circuits/package.json
+++ b/packages/circuits/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.2",
   "scripts": {
     "publish": "yarn npm publish --access=public",
-    "test": "jest tests/*.ts"
+    "test": "NODE_OPTIONS=--max_old_space_size=4096 jest tests/*.ts"
   },
   "devDependencies": {
     "circom_tester": "^0.0.19",

--- a/packages/circuits/tests/no-body-hash.test.circom
+++ b/packages/circuits/tests/no-body-hash.test.circom
@@ -1,0 +1,5 @@
+pragma circom 2.1.5;
+
+include "../email-verifier.circom";
+
+component main { public [ modulus ] } = EmailVerifier(640, 768, 121, 17, 1);

--- a/packages/circuits/tests/no-body-hash.test.ts
+++ b/packages/circuits/tests/no-body-hash.test.ts
@@ -1,0 +1,57 @@
+import { DKIMVerificationResult } from "@zk-email/helpers/src/dkim";
+import { generateCircuitInputs } from "@zk-email/helpers/src/input-helpers";
+
+const { verifyDKIMSignature } = require("@zk-email/helpers/src/dkim");
+const fs = require("fs");
+const path = require("path");
+const wasm_tester = require("circom_tester").wasm;
+const F1Field = require("ffjavascript").F1Field;
+const Scalar = require("ffjavascript").Scalar;
+
+exports.p = Scalar.fromString(
+  "21888242871839275222246405745257275088548364400416034343698204186575808495617"
+);
+
+describe("EmailVerifier : Without body check", () => {
+  jest.setTimeout(10 * 60 * 1000); // 10 minutes
+
+  let dkimResult: DKIMVerificationResult;
+  let circuit: any;
+
+  beforeAll(async () => {
+    const rawEmail = fs.readFileSync(
+      path.join(__dirname, "./test.eml"),
+      "utf8"
+    );
+    dkimResult = await verifyDKIMSignature(rawEmail);
+
+    circuit = await wasm_tester(
+      path.join(__dirname, "./no-body-hash.test.circom"),
+      {
+        // NOTE: We are running tests against pre-compiled circuit in the below path
+        // You need to manually compile when changes are made to circuit if `recompile` is set to `false`.
+        // circom "./tests/email-verifier-test.circom" --r1cs --wasm --sym --c --wat --output "./tests/compiled-test-circuit"
+        recompile: true,
+        output: path.join(__dirname, "./compiled-test-circuit"),
+        include: path.join(__dirname, "../../../node_modules"),
+      }
+    );
+  });
+
+  it("should verify email when ignore_body_hash_check is true", async function () {
+    // The result wont have shaPrecomputeSelector, maxMessageLength, maxBodyLength, ignoreBodyHashCheck
+    const emailVerifierInputs = generateCircuitInputs({
+      rsaSignature: dkimResult.signature,
+      rsaModulus: dkimResult.modulus,
+      body: dkimResult.body,
+      bodyHash: dkimResult.bodyHash,
+      message: dkimResult.message,
+      maxMessageLength: 640,
+      maxBodyLength: 768,
+      ignoreBodyHashCheck: true,
+    });
+
+    const witness = await circuit.calculateWitness(emailVerifierInputs);
+    await circuit.checkConstraints(witness);
+  });
+});

--- a/packages/helpers/src/input-helpers.ts
+++ b/packages/helpers/src/input-helpers.ts
@@ -103,16 +103,18 @@ export function generatePartialSHA({
   };
 }
 
-export function generateCircuitInputs({
-  rsaSignature,
-  rsaModulus,
-  body,
-  bodyHash,
-  message, // the message that was signed (header + bodyHash)
-  shaPrecomputeSelector, // String to split the body for SHA pre computation
-  maxMessageLength = MAX_HEADER_PADDED_BYTES, // Maximum allowed length of the message in circuit
-  maxBodyLength = MAX_BODY_PADDED_BYTES, // Maximum allowed length of the body in circuit
-}: {
+type CircuitInput = {
+  in_padded: string[];
+  modulus: string[];
+  signature: string[];
+  in_len_padded_bytes: Number;
+  precomputed_sha?: string[];
+  in_body_padded?: string[];
+  in_body_len_padded_bytes?: Number;
+  body_hash_idx?: Number;
+}
+
+export function generateCircuitInputs(params: {
   body: Buffer;
   message: Buffer;
   bodyHash: string;
@@ -121,7 +123,20 @@ export function generateCircuitInputs({
   shaPrecomputeSelector?: string;
   maxMessageLength: number;
   maxBodyLength: number;
-}) {
+  ignoreBodyHashCheck?: boolean;
+}) : CircuitInput {
+  const {
+    rsaSignature,
+    rsaModulus,
+    body,
+    bodyHash,
+    message, // the message that was signed (header + bodyHash)
+    shaPrecomputeSelector, // String to split the body for SHA pre computation
+    maxMessageLength = MAX_HEADER_PADDED_BYTES, // Maximum allowed length of the message in circuit
+    maxBodyLength = MAX_BODY_PADDED_BYTES, // Maximum allowed length of the body in circuit
+    ignoreBodyHashCheck = false, // To be used when ignore_body_hash_check is true in circuit
+  } = params;
+
   // SHA add padding
   const [messagePadded, messagePaddedLen] = sha256Pad(
     message,
@@ -144,18 +159,22 @@ export function generateCircuitInputs({
       maxRemainingBodyLength: maxBodyLength,
     });
 
-  const bodyHashIndex = message.toString().indexOf(bodyHash).toString();
 
-  const circuitInputs = {
+  const circuitInputs : CircuitInput = {
     in_padded: Uint8ArrayToCharArray(messagePadded), // Packed into 1 byte signals
     modulus: toCircomBigIntBytes(rsaModulus),
     signature: toCircomBigIntBytes(rsaSignature),
-    in_len_padded_bytes: messagePaddedLen.toString(),
-    precomputed_sha: Uint8ArrayToCharArray(precomputedSha),
-    in_body_padded: Uint8ArrayToCharArray(bodyRemaining),
-    in_body_len_padded_bytes: bodyRemainingLength.toString(),
-    body_hash_idx: bodyHashIndex,
+    in_len_padded_bytes: messagePaddedLen,
   };
+
+  if (!ignoreBodyHashCheck)  {
+    const bodyHashIndex = message.toString().indexOf(bodyHash);
+
+    circuitInputs.precomputed_sha = Uint8ArrayToCharArray(precomputedSha);
+    circuitInputs.body_hash_idx = bodyHashIndex;
+    circuitInputs.in_body_padded = Uint8ArrayToCharArray(bodyRemaining);
+    circuitInputs.in_body_len_padded_bytes = bodyRemainingLength;
+  }
 
   return circuitInputs;
 }

--- a/packages/helpers/src/input-helpers.ts
+++ b/packages/helpers/src/input-helpers.ts
@@ -107,11 +107,11 @@ type CircuitInput = {
   in_padded: string[];
   modulus: string[];
   signature: string[];
-  in_len_padded_bytes: Number;
+  in_len_padded_bytes: string;
   precomputed_sha?: string[];
   in_body_padded?: string[];
-  in_body_len_padded_bytes?: Number;
-  body_hash_idx?: Number;
+  in_body_len_padded_bytes?: string;
+  body_hash_idx?: string;
 }
 
 export function generateCircuitInputs(params: {
@@ -164,16 +164,16 @@ export function generateCircuitInputs(params: {
     in_padded: Uint8ArrayToCharArray(messagePadded), // Packed into 1 byte signals
     modulus: toCircomBigIntBytes(rsaModulus),
     signature: toCircomBigIntBytes(rsaSignature),
-    in_len_padded_bytes: messagePaddedLen,
+    in_len_padded_bytes: messagePaddedLen.toString(),
   };
 
   if (!ignoreBodyHashCheck)  {
     const bodyHashIndex = message.toString().indexOf(bodyHash);
 
     circuitInputs.precomputed_sha = Uint8ArrayToCharArray(precomputedSha);
-    circuitInputs.body_hash_idx = bodyHashIndex;
+    circuitInputs.body_hash_idx = bodyHashIndex.toString();
     circuitInputs.in_body_padded = Uint8ArrayToCharArray(bodyRemaining);
-    circuitInputs.in_body_len_padded_bytes = bodyRemainingLength;
+    circuitInputs.in_body_len_padded_bytes = bodyRemainingLength.toString();
   }
 
   return circuitInputs;

--- a/packages/twitter-verifier-circuits/helpers/generate-inputs.ts
+++ b/packages/twitter-verifier-circuits/helpers/generate-inputs.ts
@@ -31,7 +31,7 @@ export function generateTwitterVerifierCircuitInputs({
     maxBodyLength: MAX_BODY_PADDED_BYTES,
   });
 
-  const bodyRemaining = emailVerifierInputs.in_body_padded.map(c => Number(c)); // Char array to Uint8Array
+  const bodyRemaining = emailVerifierInputs.in_body_padded!.map(c => Number(c)); // Char array to Uint8Array
   const selectorBuffer = Buffer.from(STRING_PRESELECTOR);
   const usernameIndex = Buffer.from(bodyRemaining).indexOf(selectorBuffer) + selectorBuffer.length;
 


### PR DESCRIPTION
- Ignore `body_hash_idx` when `ignore_body_hash_check` is true
- Add circom tests when `ignore_body_hash_check` is `true`
- Make `sha[256]` a output signal