### PR TITLE
chore: bump circom to 2.1.6

### DIFF
--- a/packages/circuits/email-verifier.circom
+++ b/packages/circuits/email-verifier.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "circomlib/circuits/bitify.circom";
 include "circomlib/circuits/mimcsponge.circom";

--- a/packages/circuits/helpers/base64.circom
+++ b/packages/circuits/helpers/base64.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "circomlib/circuits/comparators.circom";
 

--- a/packages/circuits/helpers/bigint.circom
+++ b/packages/circuits/helpers/bigint.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "circomlib/circuits/comparators.circom";
 include "circomlib/circuits/bitify.circom";

--- a/packages/circuits/helpers/bigint_func.circom
+++ b/packages/circuits/helpers/bigint_func.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 function isNegative(x) {
     // half babyjubjub field size

--- a/packages/circuits/helpers/extract.circom
+++ b/packages/circuits/helpers/extract.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.2;
+pragma circom 2.1.6;
 include "./utils.circom";
 
 // A set of utils for shifting and packing signal arrays

--- a/packages/circuits/helpers/fp.circom
+++ b/packages/circuits/helpers/fp.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "circomlib/circuits/bitify.circom";
 include "circomlib/circuits/comparators.circom";

--- a/packages/circuits/helpers/rsa.circom
+++ b/packages/circuits/helpers/rsa.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "./fp.circom";
 

--- a/packages/circuits/helpers/sha.circom
+++ b/packages/circuits/helpers/sha.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "circomlib/circuits/bitify.circom";
 include "./sha256general.circom";

--- a/packages/circuits/helpers/sha256general.circom
+++ b/packages/circuits/helpers/sha256general.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "circomlib/circuits/sha256/constants.circom";
 include "circomlib/circuits/sha256/sha256compression.circom";

--- a/packages/circuits/helpers/sha256partial.circom
+++ b/packages/circuits/helpers/sha256partial.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "circomlib/circuits/sha256/constants.circom";
 include "circomlib/circuits/sha256/sha256compression.circom";

--- a/packages/circuits/helpers/utils.circom
+++ b/packages/circuits/helpers/utils.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "circomlib/circuits/bitify.circom";
 include "circomlib/circuits/comparators.circom";

--- a/packages/circuits/regexes/body_hash_regex.circom
+++ b/packages/circuits/regexes/body_hash_regex.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "./regex_helpers.circom";
 

--- a/packages/circuits/regexes/from_regex.circom
+++ b/packages/circuits/regexes/from_regex.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "./regex_helpers.circom";
 

--- a/packages/circuits/regexes/message_id_regex.circom
+++ b/packages/circuits/regexes/message_id_regex.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "./regex_helpers.circom";
 

--- a/packages/circuits/regexes/regex_helpers.circom
+++ b/packages/circuits/regexes/regex_helpers.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "circomlib/circuits/comparators.circom";
 include "circomlib/circuits/gates.circom";

--- a/packages/circuits/regexes/subject_regex_operation.circom
+++ b/packages/circuits/regexes/subject_regex_operation.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "./regex_helpers.circom";
 

--- a/packages/circuits/regexes/subject_regex_send.circom
+++ b/packages/circuits/regexes/subject_regex_send.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "./regex_helpers.circom";
 

--- a/packages/circuits/regexes/tofrom_domain_regex.circom
+++ b/packages/circuits/regexes/tofrom_domain_regex.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "./regex_helpers.circom";
 

--- a/packages/circuits/tests/email-verifier-test.circom
+++ b/packages/circuits/tests/email-verifier-test.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "../email-verifier.circom";
 

--- a/packages/circuits/tests/no-body-hash.test.circom
+++ b/packages/circuits/tests/no-body-hash.test.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "../email-verifier.circom";
 

--- a/packages/twitter-verifier-circuits/components/twitter_reset_regex.circom
+++ b/packages/twitter-verifier-circuits/components/twitter_reset_regex.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "../../../node_modules/@zk-email/circuits/regexes/regex_helpers.circom";
 

--- a/packages/twitter-verifier-circuits/twitter.circom
+++ b/packages/twitter-verifier-circuits/twitter.circom
@@ -1,4 +1,4 @@
-pragma circom 2.1.5;
+pragma circom 2.1.6;
 
 include "@zk-email/circuits/regexes/from_regex.circom";
 include "@zk-email/circuits/email-verifier.circom";


### PR DESCRIPTION
closes #92

There are no constraint changes from previous version, but the actual value doesn't match with the one provided in README.

```text
non-linear constraints: 2801097
linear constraints: 0
public inputs: 1
public outputs: 9
private inputs: 2631
private outputs: 0
wires: 2704830
labels: 11813196
```