### PR TITLE
feat: migrate js files to ts

### DIFF
--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -21,6 +21,14 @@
     "snarkjs": "https://github.com/sampritipanda/snarkjs.git#fef81fc51d17a734637555c6edbd585ecda02d9e"
   },
   "devDependencies": {
+    "@types/addressparser": "^1.0.3",
+    "@types/atob": "^2.1.2",
+    "@types/jest": "^29.5.1",
+    "@types/lodash": "^4.14.181",
+    "@types/mocha": "^10.0.1",
+    "@types/node": "^18.0.6",
+    "@types/node-forge": "^1.3.2",
+    "@types/psl": "^1.1.2",
     "msw": "^1.2.2"
   }
 }

--- a/packages/helpers/src/dkim/body/index.ts
+++ b/packages/helpers/src/dkim/body/index.ts
@@ -1,7 +1,7 @@
 import { SimpleHash } from './simple';
 import { RelaxedHash } from './relaxed';
 
-export const dkimBody = (canonicalization: unknown, ...options: [string, number]) => {
+export const dkimBody = (canonicalization: any, ...options: [string, number]) => {
     canonicalization = (canonicalization ?? 'simple/simple').toString().split('/').pop()?.toLowerCase().trim();
     switch (canonicalization) {
         case 'simple':

--- a/packages/helpers/src/dkim/body/index.ts
+++ b/packages/helpers/src/dkim/body/index.ts
@@ -1,8 +1,8 @@
 import { SimpleHash } from './simple';
 import { RelaxedHash } from './relaxed';
 
-const dkimBody = (canonicalization, ...options) => {
-    canonicalization = (canonicalization || 'simple/simple').toString().split('/').pop().toLowerCase().trim();
+export const dkimBody = (canonicalization: unknown, ...options: [string, number]) => {
+    canonicalization = (canonicalization ?? 'simple/simple').toString().split('/').pop()?.toLowerCase().trim();
     switch (canonicalization) {
         case 'simple':
             return new SimpleHash(...options);
@@ -12,5 +12,3 @@ const dkimBody = (canonicalization, ...options) => {
             throw new Error('Unknown body canonicalization');
     }
 };
-
-export { dkimBody };

--- a/packages/helpers/src/dkim/dkim-verifier.ts
+++ b/packages/helpers/src/dkim/dkim-verifier.ts
@@ -14,7 +14,7 @@ import { dkimBody } from "./body";
 import { generateCanonicalizedHeader } from "./header";
 import addressparser from "addressparser";
 import * as crypto from "crypto";
-import { ParseDkimHeaders, ParsedHeaders } from "dkim";
+import { ParseDkimHeaders, ParsedHeaders } from "./index";
 
 export class DkimVerifier extends MessageParser {
   envelopeFrom: string | boolean;

--- a/packages/helpers/src/dkim/header/index.ts
+++ b/packages/helpers/src/dkim/header/index.ts
@@ -1,4 +1,4 @@
-import { Options, SignatureType, SigningHeaderLines } from 'dkim';
+import { Options, SignatureType, SigningHeaderLines } from '../index';
 import { relaxedHeaders } from './relaxed';
 import { simpleHeaders } from './simple';
 

--- a/packages/helpers/src/dkim/header/index.ts
+++ b/packages/helpers/src/dkim/header/index.ts
@@ -1,11 +1,10 @@
-'use strict';
-
+import { Options, SignatureType, SigningHeaderLines } from 'dkim';
 import { relaxedHeaders } from './relaxed';
 import { simpleHeaders } from './simple';
 
-const generateCanonicalizedHeader = (type, signingHeaderLines, options) => {
+export const generateCanonicalizedHeader = (type: SignatureType, signingHeaderLines: SigningHeaderLines, options: Options) => {
     options = options || {};
-    let canonicalization = (options.canonicalization || 'simple/simple').toString().split('/').shift().toLowerCase().trim();
+    let canonicalization = (options.canonicalization || 'simple/simple').toString()?.split('/')?.shift()?.toLowerCase().trim();
     switch (canonicalization) {
         case 'simple':
             return simpleHeaders(type, signingHeaderLines, options);
@@ -15,5 +14,3 @@ const generateCanonicalizedHeader = (type, signingHeaderLines, options) => {
             throw new Error('Unknown header canonicalization');
     }
 };
-
-export { generateCanonicalizedHeader };

--- a/packages/helpers/src/dkim/header/relaxed.ts
+++ b/packages/helpers/src/dkim/header/relaxed.ts
@@ -1,9 +1,8 @@
-'use strict';
-
+import { Options, SignatureType, SigningHeaderLines } from 'dkim';
 import { formatSignatureHeaderLine, formatRelaxedLine } from '../tools';
 
 // generate headers for signing
-const relaxedHeaders = (type, signingHeaderLines, options) => {
+export const relaxedHeaders = (type: SignatureType, signingHeaderLines: SigningHeaderLines, options: Options) => {
     let { signatureHeaderLine, signingDomain, selector, algorithm, canonicalization, bodyHash, signTime, signature, instance, bodyHashedBytes } = options || {};
     let chunks = [];
 
@@ -11,7 +10,7 @@ const relaxedHeaders = (type, signingHeaderLines, options) => {
         chunks.push(formatRelaxedLine(signedHeaderLine.line, '\r\n'));
     }
 
-    let opts = false;
+    let opts: boolean | Record<string, unknown> = false;
 
     if (!signatureHeaderLine) {
         opts = {
@@ -52,7 +51,7 @@ const relaxedHeaders = (type, signingHeaderLines, options) => {
                     b: signature || 'a'.repeat(73)
                 },
                 opts
-            ),
+            ) as Record<string, string | boolean>,
             true
         );
     }
@@ -69,5 +68,3 @@ const relaxedHeaders = (type, signingHeaderLines, options) => {
 
     return { canonicalizedHeader: Buffer.concat(chunks), signatureHeaderLine, dkimHeaderOpts: opts };
 };
-
-export { relaxedHeaders };

--- a/packages/helpers/src/dkim/header/relaxed.ts
+++ b/packages/helpers/src/dkim/header/relaxed.ts
@@ -1,4 +1,4 @@
-import { Options, SignatureType, SigningHeaderLines } from 'dkim';
+import { Options, SignatureType, SigningHeaderLines } from '../index';
 import { formatSignatureHeaderLine, formatRelaxedLine } from '../tools';
 
 // generate headers for signing

--- a/packages/helpers/src/dkim/header/simple.ts
+++ b/packages/helpers/src/dkim/header/simple.ts
@@ -1,11 +1,10 @@
-'use strict';
-
+import { Options, SignatureType, SigningHeaderLines } from 'dkim';
 import { formatSignatureHeaderLine } from '../tools';
 
-const formatSimpleLine = (line, suffix) => Buffer.from(line.toString('binary') + (suffix ? suffix : ''), 'binary');
+const formatSimpleLine = (line: Buffer | string, suffix?: string) => Buffer.from(line.toString('binary') + (suffix ? suffix : ''), 'binary');
 
 // generate headers for signing
-const simpleHeaders = (type, signingHeaderLines, options) => {
+export const simpleHeaders = (type: SignatureType, signingHeaderLines: SigningHeaderLines, options: Options) => {
     let { signatureHeaderLine, signingDomain, selector, algorithm, canonicalization, bodyHash, signTime, signature, instance, bodyHashedBytes } = options || {};
     let chunks = [];
 
@@ -13,7 +12,7 @@ const simpleHeaders = (type, signingHeaderLines, options) => {
         chunks.push(formatSimpleLine(signedHeaderLine.line, '\r\n'));
     }
 
-    let opts = false;
+    let opts: boolean | Record<string, any> = false;
 
     if (!signatureHeaderLine) {
         opts = {
@@ -54,7 +53,7 @@ const simpleHeaders = (type, signingHeaderLines, options) => {
                     b: signature || 'a'.repeat(73)
                 },
                 opts
-            ),
+            ) as Record<string, string | boolean>,
             true
         );
     }
@@ -71,5 +70,3 @@ const simpleHeaders = (type, signingHeaderLines, options) => {
 
     return { canonicalizedHeader: Buffer.concat(chunks), signatureHeaderLine, dkimHeaderOpts: opts };
 };
-
-export { simpleHeaders };

--- a/packages/helpers/src/dkim/header/simple.ts
+++ b/packages/helpers/src/dkim/header/simple.ts
@@ -1,4 +1,4 @@
-import { Options, SignatureType, SigningHeaderLines } from 'dkim';
+import { Options, SignatureType, SigningHeaderLines } from '../index';
 import { formatSignatureHeaderLine } from '../tools';
 
 const formatSimpleLine = (line: Buffer | string, suffix?: string) => Buffer.from(line.toString('binary') + (suffix ? suffix : ''), 'binary');

--- a/packages/helpers/src/dkim/index.ts
+++ b/packages/helpers/src/dkim/index.ts
@@ -1,10 +1,10 @@
 import { pki } from "node-forge";
 import { DkimVerifier } from "./dkim-verifier";
-import { writeToStream } from "./tools";
+import { getSigningHeaderLines, parseDkimHeaders, parseHeaders, writeToStream } from "./tools";
 
 export const dkimVerify = async (input: Buffer, options: any = {}) => {
   let dkimVerifier = new DkimVerifier(options);
-  await writeToStream(dkimVerifier, input);
+  await writeToStream(dkimVerifier, input as any);
 
   const result = {
     //headers: dkimVerifier.headers,
@@ -33,7 +33,7 @@ export type DKIMVerificationResult = {
   publicKey: bigint;
 }
 
-export async function verifyDKIMSignature(email: Buffer) : Promise<DKIMVerificationResult> {
+export async function verifyDKIMSignature(email: Buffer): Promise<DKIMVerificationResult> {
   const result = await dkimVerify(email);
 
   if (!result.results[0]) {
@@ -55,8 +55,31 @@ export async function verifyDKIMSignature(email: Buffer) : Promise<DKIMVerificat
   return {
     signature: signatureBigInt,
     message: status.signature_header,
-    body, 
+    body,
     bodyHash,
     publicKey: BigInt(pubKeyData.n.toString()),
   }
+}
+
+export type SignatureType = 'DKIM' | 'ARC' | 'AS';
+
+export type ParsedHeaders = ReturnType<typeof parseHeaders>;
+
+export type Parsed = ParsedHeaders['parsed'][0];
+
+export type ParseDkimHeaders = ReturnType<typeof parseDkimHeaders>
+
+export type SigningHeaderLines = ReturnType<typeof getSigningHeaderLines>
+
+export interface Options {
+  signatureHeaderLine: string;
+  signingDomain?: string;
+  selector?: string;
+  algorithm?: string;
+  canonicalization: string;
+  bodyHash?: string;
+  signTime?: string | number | Date;
+  signature?: string;
+  instance: string | boolean;
+  bodyHashedBytes?: string;
 }

--- a/packages/helpers/src/dkim/message-parser.ts
+++ b/packages/helpers/src/dkim/message-parser.ts
@@ -1,5 +1,5 @@
 // Calculates relaxed body hash for a message body stream
-import { ParsedHeaders } from 'dkim';
+import { ParsedHeaders } from './index';
 import { parseHeaders } from './tools';
 import { Writable, WritableOptions } from 'stream';
 

--- a/packages/helpers/src/dkim/parse-dkim-headers.ts
+++ b/packages/helpers/src/dkim/parse-dkim-headers.ts
@@ -30,6 +30,7 @@ const valueParser = (str: string) => {
             let c = line.charAt(i);
 
             switch (state) {
+                // @ts-ignore
                 case 'key':
                     if (c === '=') {
                         state = 'value';
@@ -153,6 +154,7 @@ const headerParser = (buf: Buffer | string) => {
             let c = line.charAt(i);
 
             switch (state) {
+                // @ts-ignore
                 case 'key':
                     if (c === '=') {
                         state = 'value';
@@ -220,7 +222,7 @@ const headerParser = (buf: Buffer | string) => {
                         case '\\':
                             escaped = true;
                             break;
-
+                        // @ts-ignore
                         case quote:
                             state = lastState as string;
                         // falls through

--- a/packages/helpers/src/dkim/tools.ts
+++ b/packages/helpers/src/dkim/tools.ts
@@ -5,7 +5,7 @@ const libmime = require('libmime');
 import crypto, { KeyObject } from "crypto";
 import parseDkimHeaders from "./parse-dkim-headers";
 import psl from "psl";
-import { Parsed, SignatureType } from 'dkim';
+import { Parsed, SignatureType } from './index';
 import { DkimVerifier } from './dkim-verifier';
 
 var isNode = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14699,7 +14699,7 @@ __metadata:
     readline: ^1.3.0
   bin:
     snarkjs: build/cli.cjs
-  checksum: 6040ce61d8eefc4ffacc28a743445372caf24d64207ba6e474deba1d8b4591b255fdad8f962f89cb228f9c5af5a359d809d4408e1fd7ca64c8e1d634f1893831
+  checksum: 9011df4b58475a0b4ae988f8b459a9a4d2bb5d2b60221d0ec370a10f2492c88909768215f3b22e514b2cf24dca79818790447005a33ed6aee177b9fda6948a75
   languageName: node
   linkType: hard
 
@@ -14720,7 +14720,7 @@ __metadata:
     r1csfile: 0.0.41
   bin:
     snarkjs: build/cli.cjs
-  checksum: 03909c769b2fa2c210b0a9ef17c7132824de0aa247626a02864a35d966350e9d2769121e1fab96ce2c81284a956694afb1e2819738e784c889ed6c0fe0d305ab
+  checksum: f2050f0135d50d459ea0edddf3e394e833a2d28c6648e5889b2f896814865e5c60606e978a8a106bd5bfe7e27501c315f249db5b71895d5e7e6e9a87bfcd55ab
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3651,6 +3651,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@types/addressparser@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@types/addressparser@npm:1.0.3"
+  dependencies:
+    "@types/node": "*"
+  checksum: 7e7b6d3dfa8133b878c92a7cc1a654244a22a9f5848254c3531c0897e8e55863af194120dc247b811ce90df771903056048b1ecbdaee1c866b2c9b43bd41ead2
+  languageName: node
+  linkType: hard
+
 "@types/aria-query@npm:^5.0.1":
   version: 5.0.1
   resolution: "@types/aria-query@npm:5.0.1"
@@ -3902,6 +3911,13 @@ __metadata:
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
   checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
+  languageName: node
+  linkType: hard
+
+"@types/psl@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@types/psl@npm:1.1.2"
+  checksum: fc0a7ae56ca53157035226d964f5a37749187804c07787d25a3f8e0235130c277b52d027139d1a7058d7826014a8019d68d46e2719b0404ac8545d39d41fc43a
   languageName: node
   linkType: hard
 
@@ -4742,6 +4758,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zk-email/helpers@workspace:packages/helpers"
   dependencies:
+    "@types/addressparser": ^1.0.3
+    "@types/atob": ^2.1.2
+    "@types/jest": ^29.5.1
+    "@types/lodash": ^4.14.181
+    "@types/mocha": ^10.0.1
+    "@types/node": ^18.0.6
+    "@types/node-forge": ^1.3.2
+    "@types/psl": ^1.1.2
     addressparser: ^1.0.1
     atob: ^2.1.2
     circomlibjs: ^0.1.7
@@ -14675,7 +14699,7 @@ __metadata:
     readline: ^1.3.0
   bin:
     snarkjs: build/cli.cjs
-  checksum: 9011df4b58475a0b4ae988f8b459a9a4d2bb5d2b60221d0ec370a10f2492c88909768215f3b22e514b2cf24dca79818790447005a33ed6aee177b9fda6948a75
+  checksum: 6040ce61d8eefc4ffacc28a743445372caf24d64207ba6e474deba1d8b4591b255fdad8f962f89cb228f9c5af5a359d809d4408e1fd7ca64c8e1d634f1893831
   languageName: node
   linkType: hard
 
@@ -14696,7 +14720,7 @@ __metadata:
     r1csfile: 0.0.41
   bin:
     snarkjs: build/cli.cjs
-  checksum: f2050f0135d50d459ea0edddf3e394e833a2d28c6648e5889b2f896814865e5c60606e978a8a106bd5bfe7e27501c315f249db5b71895d5e7e6e9a87bfcd55ab
+  checksum: 03909c769b2fa2c210b0a9ef17c7132824de0aa247626a02864a35d966350e9d2769121e1fab96ce2c81284a956694afb1e2819738e784c889ed6c0fe0d305ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #131

- Migrate js files under helpers/src/dkim to ts
- Add @types to package.json
- Update yarn.lock
- Replace deprecated Buffer's `slice()` with `subarray()`