### PR TITLE
Retry download, cancel and notify user on fail

### DIFF
--- a/packages/helpers/src/zkp.ts
+++ b/packages/helpers/src/zkp.ts
@@ -25,28 +25,25 @@ async function storeArrayBuffer(keyname: string, buffer: ArrayBuffer) {
 // and named such that filename===`${name}.zkey${a}` in order for it to be found by snarkjs.
 export async function downloadFromFilename(filename: string, compressed = false) {
   const link = loadURL + filename;
-  try {
-    const zkeyResp = await fetch(link, {
-      method: "GET",
-    });
-    const zkeyBuff = await zkeyResp.arrayBuffer();
-    if (!compressed) {
-      await storeArrayBuffer(filename, zkeyBuff);
-    } else {
-      // uncompress the data
-      const zkeyUncompressed = await uncompress(zkeyBuff);
-      const rawFilename = filename.replace(zkeyExtensionRegEx, ""); // replace .gz with ""
-      // store the uncompressed data
-      console.log("storing file in localforage", rawFilename);
-      await storeArrayBuffer(rawFilename, zkeyUncompressed);
-      console.log("stored file in localforage", rawFilename);
-      // await localforage.setItem(filename, zkeyBuff);
-    }
-    console.log(`Storage of ${filename} successful!`);
-  } catch (e) {
-    console.log(`Storage of ${filename} unsuccessful, make sure IndexedDB is enabled in your browser.`);
-    console.log(e);
+
+  const zkeyResp = await fetch(link, {
+    method: "GET",
+  });
+
+  const zkeyBuff = await zkeyResp.arrayBuffer();
+  if (!compressed) {
+    await storeArrayBuffer(filename, zkeyBuff);
+  } else {
+    // uncompress the data
+    const zkeyUncompressed = await uncompress(zkeyBuff);
+    const rawFilename = filename.replace(zkeyExtensionRegEx, ""); // replace .gz with ""
+    // store the uncompressed data
+    console.log("storing file in localforage", rawFilename);
+    await storeArrayBuffer(rawFilename, zkeyUncompressed);
+    console.log("stored file in localforage", rawFilename);
+    // await localforage.setItem(filename, zkeyBuff);
   }
+  console.log(`Storage of ${filename} successful!`);
 }
 
 export const downloadProofFiles = async function (filename: string, onFileDownloaded: () => void) {
@@ -56,7 +53,7 @@ export const downloadProofFiles = async function (filename: string, onFileDownlo
     const itemCompressed = await localforage.getItem(targzFilename);
     const item = await localforage.getItem(`${filename}.zkey${c}`);
     if (item) {
-      console.log(`${filename}.zkey${c}${item ? "" : zkeyExtension} already found in localstorage!`);
+      console.log(`${filename}.zkey${c}${item ? "" : zkeyExtension} already found in localforage!`);
       onFileDownloaded();
       continue;
     }
@@ -78,7 +75,7 @@ export const uncompressProofFiles = async function (filename: string) {
     if (!itemCompressed) {
       console.error(`Error downloading file ${targzFilename}`);
     } else {
-      console.log(`${filename}.zkey${c}${item ? "" : zkeyExtension} already found in localstorage!`);
+      console.log(`${filename}.zkey${c}${item ? "" : zkeyExtension} already found in localforage!`);
       continue;
     }
     filePromises.push(downloadFromFilename(targzFilename));

--- a/packages/helpers/src/zkp.ts
+++ b/packages/helpers/src/zkp.ts
@@ -20,15 +20,24 @@ async function storeArrayBuffer(keyname: string, buffer: ArrayBuffer) {
   return await localforage.setItem(keyname, buffer);
 }
 
+async function downloadWithRetries(link: string, downloadAttempts: number) {
+  for (let i = 1; i <= downloadAttempts; i++) {
+    console.log(`download attempt ${i} for ${link}`);
+    let response = await fetch(link, { method: "GET" });
+    if (response.status == 200) {
+      return response;
+    }
+  }
+  throw new Error(`Error downloading ${link} after ${downloadAttempts} retries`);
+}
+
 // GET the compressed file from the remote server, then store it with localforage
 // Note that it must be stored as an uncompressed ArrayBuffer
 // and named such that filename===`${name}.zkey${a}` in order for it to be found by snarkjs.
 export async function downloadFromFilename(filename: string, compressed = false) {
   const link = loadURL + filename;
 
-  const zkeyResp = await fetch(link, {
-    method: "GET",
-  });
+  const zkeyResp = await downloadWithRetries(link, 3);
 
   const zkeyBuff = await zkeyResp.arrayBuffer();
   if (!compressed) {

--- a/packages/twitter-verifier-app/pages/MainPage.tsx
+++ b/packages/twitter-verifier-app/pages/MainPage.tsx
@@ -353,7 +353,7 @@ export const MainPage: React.FC<{}> = (props) => {
                 });
               }
               catch (e) {
-                console.error(e);
+                console.log(e);
                 setDisplayMessage("Error downloading proof files");
                 setStatus("error-failed-to-download");
                 return;

--- a/packages/twitter-verifier-app/pages/MainPage.tsx
+++ b/packages/twitter-verifier-app/pages/MainPage.tsx
@@ -347,9 +347,18 @@ export const MainPage: React.FC<{}> = (props) => {
                 "Downloading compressed proving files... (this may take a few minutes)"
               );
               setStatus("downloading-proof-files");
-              await downloadProofFiles(filename, () => {
-                setDownloadProgress((p) => p + 1);
-              });
+              try {
+                await downloadProofFiles(filename, () => {
+                  setDownloadProgress((p) => p + 1);
+                });
+              }
+              catch (e) {
+                console.error(e);
+                setDisplayMessage("Error downloading proof files");
+                setStatus("error-failed-to-download");
+                return;
+              }
+
               console.timeEnd("zk-dl");
               recordTimeForActivity("finishedDownloading");
 


### PR DESCRIPTION
Retry download N times.
If the download still fails, cancel the process and display "Error downloading proof files".
Fixes #102


https://github.com/zkemail/zk-email-verify/assets/667227/13e8f95e-82c6-4052-b01f-3d4209302f42

