### PR TITLE
Oz5 Update for Contracts for AA Compatibility

### DIFF
--- a/packages/contracts/DKIMRegistry.sol
+++ b/packages/contracts/DKIMRegistry.sol
@@ -13,6 +13,8 @@ import "./interfaces/IDKIMRegistry.sol";
   Input is DKIM pub key split into 17 chunks of 121 bits. You can use `helpers` package to fetch/split DKIM keys
  */
 contract DKIMRegistry is IDKIMRegistry, Ownable {
+    constructor(address _signer) Ownable(_signer) { }
+
     event DKIMPublicKeyHashRegistered(string domainName, bytes32 publicKeyHash);
     event DKIMPublicKeyHashRevoked(bytes32 publicKeyHash);
 

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,3 +1,9 @@
+## Set up
+
+```bash
+yarn install
+```
+
 ## DKIMRegistry.sol
 
 The `DKIMRegistry.sol` is a Solidity contract that serves as a registry for storing the hash of the DomainKeys Identified Mail (DKIM) public key for each domain. This contract is part of the `@zk-email/contracts` package.

--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -2,4 +2,5 @@
 src = './'
 out = 'out'
 allow_paths = ['../../node_modules']
+libs = ['../../node_modules']
 solc_version = '0.8.21'

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -6,7 +6,7 @@
     "publish": "yarn npm publish --access=public"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.9.3",
+    "@openzeppelin/contracts": "^5.0.0",
     "dotenv": "^16.3.1"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zk-email/contracts",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "scripts": {
     "build": "forge build",
     "publish": "yarn npm publish --access=public"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,5 +8,8 @@
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.0",
     "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "forge-std": "https://github.com/foundry-rs/forge-std"
   }
 }

--- a/packages/contracts/remappings.txt
+++ b/packages/contracts/remappings.txt
@@ -1,3 +1,2 @@
-@openzeppelin=../../node_modules/@openzeppelin/contracts
 @openzeppelin/contracts=../../node_modules/@openzeppelin/contracts
-@openzeppelin/contracts-upgradeable=../../node_modules/@openzeppelin/contracts-upgradeable
+@openzeppelin=../../node_modules/@openzeppelin/contracts

--- a/packages/contracts/remappings.txt
+++ b/packages/contracts/remappings.txt
@@ -1,2 +1,4 @@
 @openzeppelin/contracts=../../node_modules/@openzeppelin/contracts
 @openzeppelin=../../node_modules/@openzeppelin/contracts
+forge-std=../../node_modules/forge-std
+

--- a/packages/contracts/test/DKIMRegistry.t.sol
+++ b/packages/contracts/test/DKIMRegistry.t.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "forge-std/src/Test.sol";
@@ -17,7 +19,9 @@ contract TestDKIMRegistry is Test {
   }
 
   function test_setDKIM() public {
+    vm.prank(signer);
     dkimRegistry.setDKIMPublicKeyHash("test.com", "a81273981273bce922");
+    vm.stopPrank();
   }
 }
 

--- a/packages/contracts/test/DKIMRegistry.t.sol
+++ b/packages/contracts/test/DKIMRegistry.t.sol
@@ -1,0 +1,23 @@
+
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "forge-std/src/Test.sol";
+import "forge-std/src/console.sol";
+import "../interfaces/IDKIMRegistry.sol";
+import "../DKIMRegistry.sol";
+
+/// @title ECDSAOwnedDKIMRegistry
+/// @notice A DKIM Registry that could be updated by predefined ECDSA signer
+contract TestDKIMRegistry is Test {
+  DKIMRegistry public dkimRegistry;
+  address public signer;
+
+  constructor() {
+      dkimRegistry = new DKIMRegistry(msg.sender);
+      signer = msg.sender;
+  }
+
+  function test_setDKIM() public {
+    dkimRegistry.setDKIMPublicKeyHash("test.com", "a81273981273bce922");
+  }
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,6 +2773,7 @@ __metadata:
   dependencies:
     "@openzeppelin/contracts": ^5.0.0
     dotenv: ^16.3.1
+    forge-std: "https://github.com/foundry-rs/forge-std"
   languageName: unknown
   linkType: soft
 
@@ -4192,6 +4193,13 @@ __metadata:
   dependencies:
     is-callable: ^1.1.3
   checksum: 6c48ff2bc63362319c65e2edca4a8e1e3483a2fabc72fbe7feaf8c73db94fc7861bd53bc02c8a66a0c1dd709da6b04eec42e0abdd6b40ce47305ae92a25e5d28
+  languageName: node
+  linkType: hard
+
+"forge-std@https://github.com/foundry-rs/forge-std":
+  version: 1.7.6
+  resolution: "forge-std@https://github.com/foundry-rs/forge-std.git#commit=e4aef94c1768803a16fe19f7ce8b65defd027cfd"
+  checksum: 6fab51b92a24c97384f55dcb1b9eba29ce5043b67930b4179a9f9f4f8da85e8315163db60bec2ffbe7334135755630ba549b246db9e503e59ec93ba2f11931cc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,10 +2446,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:^4.9.3":
-  version: 4.9.3
-  resolution: "@openzeppelin/contracts@npm:4.9.3"
-  checksum: 4932063e733b35fa7669b9fe2053f69b062366c5c208b0c6cfa1ac451712100c78acff98120c3a4b88d94154c802be05d160d71f37e7d74cadbe150964458838
+"@openzeppelin/contracts@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "@openzeppelin/contracts@npm:5.0.2"
+  checksum: 0cce6fc284bd1d89e2a447027832a62f1356b44ee31088899453e10349a63a62df2f07da63d76e4c41aad9c86b96b650b2b6fc85439ef276850dda1170a047fd
   languageName: node
   linkType: hard
 
@@ -2771,7 +2771,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@zk-email/contracts@workspace:packages/contracts"
   dependencies:
-    "@openzeppelin/contracts": ^4.9.3
+    "@openzeppelin/contracts": ^5.0.0
     dotenv: ^16.3.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Needed for ether-email-auth to work for recovery. Adds a unit test for dkim registry. Note that the interface for DKIMRegistry now needs an initializer of the owner passed in on initialization. I haev major version bumped to 6.0.0 for this. Note that we should add this foundry test into the CI on Github.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

