### PR TITLE
remove unuse dependency

### DIFF
--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -22,7 +22,6 @@
     "localforage": "^1.10.0",
     "node-forge": "^1.3.1",
     "pako": "^2.1.0",
-    "pki": "^1.1.0",
     "psl": "^1.9.0",
     "snarkjs": "https://github.com/sampritipanda/snarkjs.git#fef81fc51d17a734637555c6edbd585ecda02d9e"
   },
@@ -72,40 +71,45 @@
   },
   "eslintConfig": {
     "env": {
-        "browser": true,
-        "es2021": true,
-        "node": true
+      "browser": true,
+      "es2021": true,
+      "node": true
     },
     "extends": [
-        "airbnb-base",
-        "airbnb-typescript/base"
+      "airbnb-base",
+      "airbnb-typescript/base"
     ],
     "ignorePatterns": [
-        "src/lib/**/*",
-        "tests/**/*",
-        "dist",
-        "node_modules"
+      "src/lib/**/*",
+      "tests/**/*",
+      "dist",
+      "node_modules"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-        "ecmaVersion": 12,
-        "sourceType": "module",
-        "project": "./tsconfig.json"
+      "ecmaVersion": 12,
+      "sourceType": "module",
+      "project": "./tsconfig.json"
     },
     "plugins": [
-        "@typescript-eslint"
+      "@typescript-eslint"
     ],
     "rules": {
-        "max-len": ["error", { "code": 150 }],
-        "import/prefer-default-export": "off",
-        "no-await-in-loop": "off",
-        "no-restricted-syntax": "off",
-        "no-plusplus": "off",
-        "no-bitwise": "off",
-        "no-console": "off",
-        "no-continue": "off",
-        "@typescript-eslint/no-use-before-define": "off",
-        "prefer-destructuring": "off"
+      "max-len": [
+        "error",
+        {
+          "code": 150
+        }
+      ],
+      "import/prefer-default-export": "off",
+      "no-await-in-loop": "off",
+      "no-restricted-syntax": "off",
+      "no-plusplus": "off",
+      "no-bitwise": "off",
+      "no-console": "off",
+      "no-continue": "off",
+      "@typescript-eslint/no-use-before-define": "off",
+      "prefer-destructuring": "off"
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2826,7 +2826,6 @@ __metadata:
     msw: ^1.2.2
     node-forge: ^1.3.1
     pako: ^2.1.0
-    pki: ^1.1.0
     psl: ^1.9.0
     snarkjs: "https://github.com/sampritipanda/snarkjs.git#fef81fc51d17a734637555c6edbd585ecda02d9e"
     typescript: ^5.2.2
@@ -7145,16 +7144,6 @@ __metadata:
   dependencies:
     find-up: ^4.0.0
   checksum: 9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
-  languageName: node
-  linkType: hard
-
-"pki@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "pki@npm:1.1.0"
-  peerDependencies:
-    "@pulumi/kubernetes": ^0.25.6
-    "@pulumi/pulumi": ^0.17.28
-  checksum: 31b4ddc413be8508e816204d0eb52597ad23b02c6c0713b486967de6e7e4c42b560d1a8422702d32374c613c9302e6061a35ffbd1c1c5986d546798d775927a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

I had some issue about grpc and node-gyp during installing the @zk-email/helper(with `pnpm add`). After analysis, [pki](https://www.npmjs.com/package/pki) doesn't be imported and I can't find the source code for the lib.

## Type of Change

Remove unused dependency.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have discussed with the team prior to submitting this PR
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
