### PR TITLE
[BUG FIX] Fix SelectRegexReveal

### DIFF
--- a/packages/circuits/utils/regex.circom
+++ b/packages/circuits/utils/regex.circom
@@ -19,7 +19,7 @@ template SelectRegexReveal(maxArrayLen, maxRevealLen) {
 
     signal output out[maxRevealLen];
 
-    var bitLength = log2Ceil(maxArrayLen);
+    var bitLength = log2Ceil(maxArrayLen + maxRevealLen - 1);
 
     signal isStartIndex[maxArrayLen];
     signal isZero[maxArrayLen];

--- a/packages/circuits/utils/regex.circom
+++ b/packages/circuits/utils/regex.circom
@@ -11,7 +11,7 @@ include "./bytes.circom";
 /// @param maxRevealLen Maximum length of the reveal part
 /// @input in Input array; assumes elements to be bytes
 /// @input startIndex The index from which reveal part starts; assumes a valid index, 
-///                   and `startIndex + maxRevealLen - 1` fits in `ceil(log2((maxArrayLen))` bits.
+///                   and `startIndex + maxRevealLen - 1` fits in `ceil(log2((maxArrayLen + maxRevealLen - 1))` bits.
 /// @output out Revealed data array
 template SelectRegexReveal(maxArrayLen, maxRevealLen) {
     signal input in[maxArrayLen];


### PR DESCRIPTION
## Description

When the `startIndex` in `SelectRegexReveal` was large enough, `GreaterThan(bitLength)` at the line 36 of `regex.circom` failed because its second argument `startIndex + maxRevealLen - 1` was larger than `bitLength=log2Ceil(maxArrayLen)` bits.
This bug made tests in [ether-email-auth](https://github.com/zkemail/ether-email-auth/tree/d0b0c9307f2e1babe747657c5708bd2974aa1a27/packages/circuits/tests) failed.

I fixed that definition of `bitLength` to `bitLength=log2Ceil(maxArrayLen + maxRevealLen - 1)`, allowing the maximum length of the second argument.
I confirmed that circuit tests in zk-email-verify and the above tests in ether-email-auth passed on my local environment after this fix.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have discussed with the team prior to submitting this PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
