### PR TITLE
fix: remove-soft-line-break at the beginning

### DIFF
--- a/packages/circuits/helpers/remove-soft-line-breaks.circom
+++ b/packages/circuits/helpers/remove-soft-line-breaks.circom
@@ -89,7 +89,12 @@ template RemoveSoftLineBreaks(maxLength) {
     }
 
     // Calculate powers of r for encoded
-    rEnc[0] <== 1;
+    muxEnc[0] = Mux1();
+    muxEnc[0].c[0] <== r;
+    muxEnc[0].c[1] <== 1;
+    muxEnc[0].s <== shouldZero[0];
+    rEnc[0] <== muxEnc[0].out;
+
     for (var i = 1; i < maxLength; i++) {
         muxEnc[i] = Mux1();
         muxEnc[i].c[0] <== rEnc[i - 1] * r;
@@ -99,19 +104,19 @@ template RemoveSoftLineBreaks(maxLength) {
     }
 
     // Calculate powers of r for decoded
-    rDec[0] <== 1;
+    rDec[0] <== r;
     for (var i = 1; i < maxLength; i++) {
         rDec[i] <== rDec[i - 1] * r;
     }
 
     // Calculate rlc for processed
-    sumEnc[0] <== processed[0];
+    sumEnc[0] <== rEnc[0] * processed[0];
     for (var i = 1; i < maxLength; i++) {
         sumEnc[i] <== sumEnc[i - 1] + rEnc[i] * processed[i];
     }
 
     // Calculate rlc for decoded
-    sumDec[0] <== decoded[0];
+    sumDec[0] <== rDec[0] * decoded[0];
     for (var i = 1; i < maxLength; i++) {
         sumDec[i] <== sumDec[i - 1] + rDec[i] * decoded[i];
     }

--- a/packages/circuits/tests/remove-soft-line-breaks.test.ts
+++ b/packages/circuits/tests/remove-soft-line-breaks.test.ts
@@ -168,9 +168,7 @@ describe('RemoveSoftLineBreaks', () => {
     });
   });
 
-  // Note: The circuit currently does not handle the case when the encoded input starts with a soft line break.
-  // This test is included to document the expected behavior, but it will fail with the current implementation.
-  xit('should handle input with soft line break at the beginning', async () => {
+  it('should handle input with soft line break at the beginning', async () => {
     const input = {
       encoded: [61, 13, 10, 104, 101, 108, 108, 111, ...Array(24).fill(0)],
       decoded: [104, 101, 108, 108, 111, ...Array(27).fill(0)],


### PR DESCRIPTION
## Description

This PR includes a bug fix in the `remove-soft-line-breaks` template where the template could not handle soft-line breaks at the beginning of the email body.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have discussed with the team prior to submitting this PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
