### PR TITLE
Feat/fix select regex reveal

### DIFF
--- a/packages/circuits/tests/select-regex-reveal.test.ts
+++ b/packages/circuits/tests/select-regex-reveal.test.ts
@@ -1,0 +1,117 @@
+import { wasm } from "circom_tester";
+import path from "path";
+
+
+describe("Select Regex Reveal", () => {
+    jest.setTimeout(10 * 60 * 1000); // 10 minutes
+
+    let circuit: any;
+
+    beforeAll(async () => {
+        circuit = await wasm(
+            path.join(__dirname, "./test-circuits/select-regex-reveal-test.circom"),
+            {
+                recompile: true,
+                include: path.join(__dirname, "../../../node_modules"),
+            }
+        );
+    });
+
+    it("should reveal the substring with maximum revealed length", async function () {
+        let input = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        const startIndex = Math.floor(Math.random() * 24);
+        const revealed = Array.from("zk email").map(char => char.charCodeAt(0));
+        for (let i = 0; i < revealed.length; i++) {
+            input[startIndex + i] = revealed[i];
+        }
+        const witness = await circuit.calculateWitness({
+            in: input,
+            startIndex: startIndex,
+        });
+        await circuit.checkConstraints(witness);
+        await circuit.assertOut(witness, { out: revealed })
+    });
+
+    it("should reveal the substring with non-maximum revealed length", async function () {
+        let input = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        const startIndex = 30;
+        const revealed = Array.from("zk").map(char => char.charCodeAt(0));
+        for (let i = 0; i < revealed.length; i++) {
+            input[startIndex + i] = revealed[i];
+        }
+        const witness = await circuit.calculateWitness({
+            in: input,
+            startIndex: startIndex,
+        });
+        await circuit.checkConstraints(witness);
+        await circuit.assertOut(witness, { out: revealed.concat([0, 0, 0, 0, 0, 0]) })
+    });
+
+    it("should fail when all zero", async function () {
+        let input = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        const startIndex = Math.floor(Math.random() * 32);
+        try {
+            const witness = await circuit.calculateWitness({
+                in: input,
+                startIndex: startIndex,
+            });
+            await circuit.checkConstraints(witness);
+        } catch (error) {
+            expect((error as Error).message).toMatch("Assert Failed");
+        }
+    });
+
+    it("should fail when startIndex is 0", async function () {
+        let input = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        const startIndex = 1 + Math.floor(Math.random() * 24);
+        const revealed = Array.from("zk email").map(char => char.charCodeAt(0));
+        for (let i = 0; i < revealed.length; i++) {
+            input[startIndex + i] = revealed[i];
+        }
+        try {
+            const witness = await circuit.calculateWitness({
+                in: input,
+                startIndex: startIndex - 1,
+            });
+            await circuit.checkConstraints(witness);
+        } catch (error) {
+            expect((error as Error).message).toMatch("Assert Failed");
+        }
+    });
+
+    it("should fail when startIndex is not before 0", async function () {
+        let input = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        const startIndex = Math.floor(Math.random() * 23);
+        const revealed = Array.from("zk email").map(char => char.charCodeAt(0));
+        for (let i = 0; i < revealed.length; i++) {
+            input[startIndex + i] = revealed[i];
+        }
+        try {
+            const witness = await circuit.calculateWitness({
+                in: input,
+                startIndex: startIndex + 1,
+            });
+            await circuit.checkConstraints(witness);
+        } catch (error) {
+            expect((error as Error).message).toMatch("Assert Failed");
+        }
+    });
+
+    it("should fail when startIndex is larger than max length", async function () {
+        let input = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        const startIndex = Math.floor(Math.random() * 24);
+        const revealed = Array.from("zk email").map(char => char.charCodeAt(0));
+        for (let i = 0; i < revealed.length; i++) {
+            input[startIndex + i] = revealed[i];
+        }
+        try {
+            const witness = await circuit.calculateWitness({
+                in: input,
+                startIndex: 32
+            });
+            await circuit.checkConstraints(witness);
+        } catch (error) {
+            expect((error as Error).message).toMatch("Assert Failed");
+        }
+    });
+});

--- a/packages/circuits/tests/test-circuits/select-regex-reveal-test.circom
+++ b/packages/circuits/tests/test-circuits/select-regex-reveal-test.circom
@@ -1,0 +1,5 @@
+pragma circom 2.1.6;
+
+include "../../utils/regex.circom";
+
+component main = SelectRegexReveal(32,8);

--- a/packages/circuits/utils/regex.circom
+++ b/packages/circuits/utils/regex.circom
@@ -7,6 +7,7 @@ include "./bytes.circom";
 /// @title SelectRegexReveal
 /// @notice Returns reveal bytes of a regex match from the input
 /// @notice Verifies data before and after (maxRevealLen) reveal part is zero
+/// @notice Assumes that there is only one consecutive sequence of non-zero bytes in `in`.
 /// @param maxArrayLen Maximum length of the input array
 /// @param maxRevealLen Maximum length of the reveal part
 /// @input in Input array; assumes elements to be bytes
@@ -25,6 +26,10 @@ template SelectRegexReveal(maxArrayLen, maxRevealLen) {
     signal isZero[maxArrayLen];
     signal isPreviousZero[maxArrayLen];
     signal isAboveMaxRevealLen[maxArrayLen];
+
+    // Assert startIndex < maxArrayLen
+    signal isValidStartIndex <== LessThan(bitLength)([startIndex, maxArrayLen]);
+    isValidStartIndex === 1;
 
     isPreviousZero[0] <== 1;
     for(var i = 0; i < maxArrayLen; i++) {


### PR DESCRIPTION
## Description
This PR has the following three updates.

1. Fix the `SelectRegexReveal` template in `circuits/utils/regex.circom` to constrain that the given `startIndex` is less than `maxArrayLen`.
2. Add a note about an assumption that there should be only one consecutive sequence of non-zero bytes in `in` given to the `SelectRegexReveal` template.
3. Add new tests for the `SelectRegexReveal` template to `circuits/tests/select-regex-reveal.test.ts`.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] I have discussed with the team prior to submitting this PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
