### PR TITLE
Replace if/loop conditions dependency on input signals with ternary operator.

### DIFF
--- a/packages/circuits/lib/bigint-func.circom
+++ b/packages/circuits/lib/bigint-func.circom
@@ -207,7 +207,7 @@ function long_div(n, k, m, a, b){
 // assumes leading digit of b is at least 2 ** (n - 1)
 // 0 <= a < (2**n) * b
 function short_div_norm(n, k, a, b) {
-   var qhat = (a[k] * (1 << n) + a[k - 1]) \ b[k - 1];
+   var qhat = b[k-1] == 0 ? 0 : (a[k] * (1 << n) + a[k - 1]) \ b[k - 1];
    var v = (1 << n) - 1;
    qhat = qhat > v ? v : qhat;
 


### PR DESCRIPTION
 For compatibility with github.com/iden3/circom-witnesscalc.

## Description

For now, `circom-witnesscalc` does not support input signals in the branch and loop conditions. I have replaced few such conditions with ternary operator that is supported by `circom-witnesscalc`. Now the witness for circuit https://github.com/zk-passport/openpassport/blob/main/circuits/circuits/register/register_rsa_65537_sha256.circom can be calculated using `iden3/circom-witnesscalc`.

The demo for this witness generation can be found in https://github.com/olomix/witnesscalc-tests repository. All commands required to install dependencies, generate witness and then validate it are specified in the `./run.sh` script. It can be run from the repository directory and all dependencies would be installed locally inside this directory. Repository can be safely deleted afterward without any trash in the system. Everything script installs and generates are documented inside comments of this script.