### PR TITLE
Add r < p check to FpMul

### DIFF
--- a/packages/circuits/lib/fp.circom
+++ b/packages/circuits/lib/fp.circom
@@ -12,7 +12,7 @@ include "./bigint-func.circom";
 /// @param a Input 1 to FpMul; assumes to consist of `k` chunks, each of which must fit in `n` bits
 /// @param b Input 2 to FpMul; assumes to consist of `k` chunks, each of which must fit in `n` bits
 /// @param p The modulus; assumes to consist of `k` chunks, each of which must fit in `n` bits
-/// @output out The result of the FpMul
+/// @output out The result of the FpMul; asserted to be less than `p`  
 template FpMul(n, k) {
     assert(n + n + log_ceil(k) + 2 <= 252);
 

--- a/packages/circuits/lib/fp.circom
+++ b/packages/circuits/lib/fp.circom
@@ -41,7 +41,7 @@ template FpMul(n, k) {
     component q_range_check[k];
     signal r[k];
     component r_range_check[k];
-    component r_p_range_check = BigLessThan(n,k);
+    component r_p_lt_check = BigLessThan(n,k);
     for (var i = 0; i < k; i++) {
         q[i] <-- long_div_out[0][i];
         q_range_check[i] = Num2Bits(n);
@@ -51,10 +51,10 @@ template FpMul(n, k) {
         r_range_check[i] = Num2Bits(n);
         r_range_check[i].in <== r[i];
 
-        r_p_range_check.a[i] <== r[i];
-        r_p_range_check.b[i] <== p[i];
+        r_p_lt_check.a[i] <== r[i];
+        r_p_lt_check.b[i] <== p[i];
     }
-    r_p_range_check.out === 1;
+    r_p_lt_check.out === 1;
 
     signal v_pq_r[2*k-1];
     for (var x = 0; x < 2*k-1; x++) {

--- a/packages/circuits/tests/fp-mul.test.ts
+++ b/packages/circuits/tests/fp-mul.test.ts
@@ -20,7 +20,7 @@ describe('FpMul', () => {
         circuit2 = await wasm_tester(
             path.join(
                 __dirname,
-                './test-circuits/fp-mul-test2.circom'
+                './test-circuits/fp-mul-test-range-check.circom'
             ),
             {
                 recompile: true,

--- a/packages/circuits/tests/fp-mul.test.ts
+++ b/packages/circuits/tests/fp-mul.test.ts
@@ -38,7 +38,6 @@ describe('FpMul', () => {
         };
 
         const witness = await circuit1.calculateWitness(input);
-        console.log(witness);
         await circuit1.checkConstraints(witness);
 
         await circuit1.assertOut(witness, {
@@ -58,7 +57,6 @@ describe('FpMul', () => {
         expect.assertions(1);
         try {
             const witness = await circuit2.calculateWitness(input);
-            console.log(witness);
             await circuit2.checkConstraints(witness);
         } catch (error) {
             expect((error as Error).message).toMatch("Assert Failed");

--- a/packages/circuits/tests/fp-mul.test.ts
+++ b/packages/circuits/tests/fp-mul.test.ts
@@ -1,0 +1,68 @@
+import { wasm as wasm_tester } from 'circom_tester';
+import path from 'path';
+
+describe('FpMul', () => {
+    let circuit1: any;
+    let circuit2: any;
+
+    beforeAll(async () => {
+        circuit1 = await wasm_tester(
+            path.join(
+                __dirname,
+                './test-circuits/fp-mul-test.circom'
+            ),
+            {
+                recompile: true,
+                include: path.join(__dirname, '../../../node_modules'),
+                output: path.join(__dirname, './compiled-test-circuits'),
+            }
+        );
+        circuit2 = await wasm_tester(
+            path.join(
+                __dirname,
+                './test-circuits/fp-mul-test2.circom'
+            ),
+            {
+                recompile: true,
+                include: path.join(__dirname, '../../../node_modules'),
+                output: path.join(__dirname, './compiled-test-circuits'),
+            }
+        );
+    });
+
+    it('should correctly match with the output', async () => {
+        const input = {
+            a: [1, 0, 1, 0],
+            b: [0, 1, 1, 0],
+            p: [1, 1, 1, 1]
+        };
+
+        const witness = await circuit1.calculateWitness(input);
+        console.log(witness);
+        await circuit1.checkConstraints(witness);
+
+        await circuit1.assertOut(witness, {
+            out: [0, 0, 0, 0],
+        });
+    });
+
+    it('should fail when r exceeds p', async () => {
+        const input = {
+            a: [4, 0],
+            b: [4, 0],
+            p: [5, 0],
+            q: [2, 0],
+            r: [6, 0]
+        };
+
+        expect.assertions(1);
+        try {
+            const witness = await circuit2.calculateWitness(input);
+            console.log(witness);
+            await circuit2.checkConstraints(witness);
+        } catch (error) {
+            expect((error as Error).message).toMatch("Assert Failed");
+        }
+    });
+
+});

--- a/packages/circuits/tests/test-circuits/fp-mul-test-range-check.circom
+++ b/packages/circuits/tests/test-circuits/fp-mul-test-range-check.circom
@@ -8,13 +8,15 @@ include "../../lib/bigint.circom";
 include "../../lib/bigint-func.circom";
 
 
-/// @title FpMul
-/// @notice Multiple two numbers in Fp
+/// @title FpMul_TestRangeCheck
+/// @notice Multiple two numbers in Fp, where q and r are also provided as inputs only for test purposes
 /// @param a Input 1 to FpMul; assumes to consist of `k` chunks, each of which must fit in `n` bits
 /// @param b Input 2 to FpMul; assumes to consist of `k` chunks, each of which must fit in `n` bits
 /// @param p The modulus; assumes to consist of `k` chunks, each of which must fit in `n` bits
+/// @param q The quotient; assumes to consist of `k` chunks, each of which must fit in `n` bits
+/// @param r The remainder; assumes to consist of `k` chunks, each of which must fit in `n` bits
 /// @output out The result of the FpMul
-template FpMul(n, k) {
+template FpMul_TestRangeCheck(n, k) {
     assert(n + n + log_ceil(k) + 2 <= 252);
 
     signal input a[k];

--- a/packages/circuits/tests/test-circuits/fp-mul-test-range-check.circom
+++ b/packages/circuits/tests/test-circuits/fp-mul-test-range-check.circom
@@ -32,7 +32,6 @@ template FpMul_TestRangeCheck(n, k) {
         var v_a = poly_eval(k, a, x);
         var v_b = poly_eval(k, b, x);
         v_ab[x] <== v_a * v_b;
-        log("v_a", v_a, "v_b", v_b, "v_ab", v_ab[x]);
     }
 
 
@@ -60,13 +59,11 @@ template FpMul_TestRangeCheck(n, k) {
         var v_q = poly_eval(k, q, x);
         var v_r = poly_eval(k, r, x);
         v_pq_r[x] <== v_p * v_q + v_r;
-        log("v_p:", v_p, "v_q:", v_q, "v_r:", v_r, "v_pq_r:", v_pq_r[x]);
     }
 
     signal v_t[2*k-1];
     for (var x = 0; x < 2*k-1; x++) {
         v_t[x] <== v_ab[x] - v_pq_r[x];
-        log("v_t", v_t[x]);
     }
 
     var t[200] = poly_interp(2*k-1, v_t);

--- a/packages/circuits/tests/test-circuits/fp-mul-test-range-check.circom
+++ b/packages/circuits/tests/test-circuits/fp-mul-test-range-check.circom
@@ -40,7 +40,7 @@ template FpMul_TestRangeCheck(n, k) {
     // know it fits into k chunks and can do size n range checks.
     component q_range_check[k];
     component r_range_check[k];
-    component r_p_range_check = BigLessThan(n,k);
+    component r_p_lt_check = BigLessThan(n,k);
     for (var i = 0; i < k; i++) {
         q_range_check[i] = Num2Bits(n);
         q_range_check[i].in <== q[i];
@@ -48,10 +48,10 @@ template FpMul_TestRangeCheck(n, k) {
         r_range_check[i] = Num2Bits(n);
         r_range_check[i].in <== r[i];
 
-        r_p_range_check.a[i] <== r[i];
-        r_p_range_check.b[i] <== p[i];
+        r_p_lt_check.a[i] <== r[i];
+        r_p_lt_check.b[i] <== p[i];
     }
-    r_p_range_check.out === 1;
+    r_p_lt_check.out === 1;
 
     signal v_pq_r[2*k-1];
     for (var x = 0; x < 2*k-1; x++) {

--- a/packages/circuits/tests/test-circuits/fp-mul-test-range-check.circom
+++ b/packages/circuits/tests/test-circuits/fp-mul-test-range-check.circom
@@ -81,4 +81,4 @@ template FpMul_TestRangeCheck(n, k) {
 }
 
 
-component main = FpMul(4, 2);
+component main = FpMul_TestRangeCheck(4, 2);

--- a/packages/circuits/tests/test-circuits/fp-mul-test.circom
+++ b/packages/circuits/tests/test-circuits/fp-mul-test.circom
@@ -1,0 +1,5 @@
+pragma circom 2.1.6;
+
+include "../../lib/fp.circom";
+
+component main = FpMul(2, 4);

--- a/packages/circuits/tests/test-circuits/fp-mul-test2.circom
+++ b/packages/circuits/tests/test-circuits/fp-mul-test2.circom
@@ -1,10 +1,11 @@
 pragma circom 2.1.6;
 
+
 include "circomlib/circuits/bitify.circom";
 include "circomlib/circuits/comparators.circom";
 include "circomlib/circuits/sign.circom";
-include "./bigint.circom";
-include "./bigint-func.circom";
+include "../../lib/bigint.circom";
+include "../../lib/bigint-func.circom";
 
 
 /// @title FpMul
@@ -19,6 +20,8 @@ template FpMul(n, k) {
     signal input a[k];
     signal input b[k];
     signal input p[k];
+    signal input q[k];
+    signal input r[k];
 
     signal output out[k];
 
@@ -27,27 +30,20 @@ template FpMul(n, k) {
         var v_a = poly_eval(k, a, x);
         var v_b = poly_eval(k, b, x);
         v_ab[x] <== v_a * v_b;
+        log("v_a", v_a, "v_b", v_b, "v_ab", v_ab[x]);
     }
 
-    var ab[200] = poly_interp(2*k-1, v_ab);
-    // ab_proper has length 2*k
-    var ab_proper[100] = getProperRepresentation(n + n + log_ceil(k), n, 2*k-1, ab);
 
-    var long_div_out[2][100] = long_div(n, k, k, ab_proper, p);
 
     // Since we're only computing a*b, we know that q < p will suffice, so we
     // know it fits into k chunks and can do size n range checks.
-    signal q[k];
     component q_range_check[k];
-    signal r[k];
     component r_range_check[k];
     component r_p_range_check = BigLessThan(n,k);
     for (var i = 0; i < k; i++) {
-        q[i] <-- long_div_out[0][i];
         q_range_check[i] = Num2Bits(n);
         q_range_check[i].in <== q[i];
 
-        r[i] <-- long_div_out[1][i];
         r_range_check[i] = Num2Bits(n);
         r_range_check[i].in <== r[i];
 
@@ -62,11 +58,13 @@ template FpMul(n, k) {
         var v_q = poly_eval(k, q, x);
         var v_r = poly_eval(k, r, x);
         v_pq_r[x] <== v_p * v_q + v_r;
+        log("v_p:", v_p, "v_q:", v_q, "v_r:", v_r, "v_pq_r:", v_pq_r[x]);
     }
 
     signal v_t[2*k-1];
     for (var x = 0; x < 2*k-1; x++) {
         v_t[x] <== v_ab[x] - v_pq_r[x];
+        log("v_t", v_t[x]);
     }
 
     var t[200] = poly_interp(2*k-1, v_t);
@@ -79,3 +77,6 @@ template FpMul(n, k) {
         out[i] <== r[i];
     }
 }
+
+
+component main = FpMul(4, 2);


### PR DESCRIPTION
## Description
This PR fixes a potential attack vector in the `FpMul` circom template such that a remainder `r` larger than or equal to a module `p` can pass constraints.
Example: `a=4`, `b=4`, `p=5`, `q=2`, `r=6`.
To fix this vulnerability, I added a range check `r < p` to the `FpMul` circom template.


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have discussed with the team prior to submitting this PR
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
