### PR TITLE
Grammar and Style Improvements in Documentation and Error Messages

### DIFF
--- a/packages/helpers/src/dkim/index.ts
+++ b/packages/helpers/src/dkim/index.ts
@@ -6,7 +6,7 @@ import { resolveDNSHTTP } from './dns-over-http';
 import { resolveDNSFromZKEmailArchive } from './dns-archive';
 
 // `./mailauth` is modified version of https://github.com/postalsys/mailauth
-// Main modification are including emailHeaders in the DKIM result, making it work in the browser, add types
+// Main modifications are including emailHeaders in the DKIM result, making it work in the browser, add types
 // TODO: Fork the repo and make the changes; consider upstream to original repo
 
 export interface DKIMVerificationResult {
@@ -122,7 +122,7 @@ async function tryVerifyDKIM(
   let domainToVerifyDKIM = domain;
   if (!domainToVerifyDKIM) {
     if (dkimVerifier.headerFrom.length > 1) {
-      throw new Error('Multiple From header in email and domain for verification not specified');
+      throw new Error('Multiple From headers in email and domain for verification not specified');
     }
 
     domainToVerifyDKIM = dkimVerifier.headerFrom[0].split('@')[1];

--- a/packages/helpers/src/dkim/sanitizers.ts
+++ b/packages/helpers/src/dkim/sanitizers.ts
@@ -10,7 +10,7 @@ function setHeaderValue(email: string, header: string, value: string) {
   return email.replace(getHeaderValue(email, header), value);
 }
 
-// Google sets their own Message-ID and put the original one  in X-Google-Original-Message-ID
+// Google sets their own Message-ID and puts the original one  in X-Google-Original-Message-ID
 // when ARC forwarding
 // TODO: Add test for this
 function revertGoogleMessageId(email: string): string {
@@ -28,7 +28,7 @@ function revertGoogleMessageId(email: string): string {
   return email;
 }
 
-// Remove labels inserted to Subject - `[ListName] Newsletter 2024` to `Newsletter 2024`
+// Remove labels inserted in Subject - `[ListName] Newsletter 2024` to `Newsletter 2024`
 function removeLabels(email: string): string {
   // Replace Subject: [label] with Subject:
   const sanitized = email.replace(/Subject: \[.*\]/, 'Subject:');


### PR DESCRIPTION

## Changes Made

### packages/helpers/src/dkim/index.ts

1. Comment correction:
   - Old: "Main modification are"
   - New: "Main modifications are"
   Reason: Fixed subject-verb agreement as "modifications" is plural.

2. Error message correction:
   - Old: "Multiple From header"
   - New: "Multiple From headers"
   Reason: Fixed plural form as the error refers to multiple headers.


### packages/helpers/src/dkim/sanitizers.ts

1. Comment correction:
   - Old: "and put"
   - New: "and puts"
   Reason: Fixed subject-verb agreement with "Google" as the subject.

2. Preposition correction:
   - Old: "labels inserted to Subject"
   - New: "labels inserted in Subject"
   Reason: Used correct preposition for this context.

