### PR TITLE
Fix hyphenation in "right-hand" phrase in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ Note that it is completely client side and [open source](https://github.com/zk-e
 
 ## Verifying Signatures
 
-To verify a group signature, simply paste the resulting proof on the right hand
+To verify a group signature, simply paste the resulting proof on the right-hand
 side and click the `Verify` button. We will try to populate some signals.
 
 ## Advanced Understanding


### PR DESCRIPTION
This pull request fixes a minor typo in the `README.md` file, where "right hand" was missing a hyphen. The correct form is "right-hand" to indicate a compound adjective. 

### Changes:
- Corrected the phrase "right hand" to "right-hand" in the **docs/README.md** file.

Fixes #<issue_number> (if applicable)

## Type of Change:
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] I have discussed with the team prior to submitting this PR
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
