### PR TITLE
fix: Correct division operator in log2Ceil function

### DIFF
--- a/packages/circuits/utils/functions.circom
+++ b/packages/circuits/utils/functions.circom
@@ -10,7 +10,7 @@ function log2Ceil(a) {
 
     while (n > 0) {
         r++;
-        n \= 2;
+        n /= 2;
     }
 
     return r;


### PR DESCRIPTION
Replace incorrect '\=' operator with '/=' in log2Ceil function for proper division operation.