### PR TITLE
Remove assertion for startIndex in SelectRegexReveal template

### DIFF
--- a/packages/circuits/utils/regex.circom
+++ b/packages/circuits/utils/regex.circom
@@ -36,9 +36,6 @@ template SelectRegexReveal(maxArrayLen, maxRevealLen) {
         }
         isAboveMaxRevealLen[i] <== GreaterThan(bitLength)([i, startIndex + maxRevealLen - 1]);
 
-        // Assert startIndex is not zero
-        isStartIndex[i] * isZero[i] === 0;
-
         // Assert value before startIndex is zero
         // ZK-Regex circuit contstrains that every byte before the reveal part is zero
         // This is assuming matched data doesn't contain 0 (null) byte


### PR DESCRIPTION
## Description

The `SelectRegexReveal` component is used in several circuits, such as email authentication. This component contains a check that asserts the first index of the reveal is non-zero. However, this check causes issues with non-Gmail domains.

Proposed Solution
We have two possible approaches to address this issue:

1 - Remove the check entirely: This simplifies the solution but raises the question—Is this safe? Could it cause issues in other cases?

2 - Add an input to disable this check: This would maintain backward compatibility but requires breaking changes to the interface and updating downstream projects.

Given these considerations, option 1 (removing the check) is proposed in this PR.

Action
Please review and merge if this approach is acceptable.