### PR TITLE
build: update setup-node to v4

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -19,7 +19,7 @@ jobs:
             nlohmann-json3-dev
 
       - name: Set Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Set Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       


### PR DESCRIPTION
Updated actions/setup-node to v4 for better compatibility with the latest runner environments. Workflows only updated—no functional changes. Release notes: https://github.com/actions/setup-node/releases/tag/v4.0.0