### PR TITLE
Fix broken Installation link in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ For a deeper dive, read our full [blog post](https://blog.aayushg.com/posts/zkem
 
 ## Sections
 
-### [Installation](./zkEmailDocs/Installation/README.md)
+### [Installation](./zk-email-docs/Installation/README.md)
 
 Get started with zkEmail, install our SDKs so that you can build your own application.
 


### PR DESCRIPTION
Updated the Installation section link in docs/README.md to point to the correct path (./zk-email-docs/Installation/README.md). This resolves a broken link issue and ensures users can access the installation instructions without errors.

