### PR TITLE
fix: regex dns query

### DIFF
--- a/packages/helpers/src/dkim/dns-over-http.ts
+++ b/packages/helpers/src/dkim/dns-over-http.ts
@@ -58,13 +58,13 @@ export class DoH {
             if (ans.type === DoH.DoHTypeTXT) {
               let dkimRecord = ans.data;
               /*
-                  Remove all double quotes
+                  Remove all double quotes and spaces around them
                   Some DNS providers wrap TXT records in double quotes, 
                   and others like Cloudflare may include them. According to 
                   TXT (potentially multi-line) and DKIM (Base64 data) standards,
                   we can directly remove all double quotes from the DKIM public key.
               */
-              dkimRecord = dkimRecord.replace(/"/g, '');
+              dkimRecord = dkimRecord.replace(/\s*"\s*/g, '');
               return dkimRecord;
             }
           }


### PR DESCRIPTION
## Description

- fix regex in DNS query over https
-  tries cloudflare dns query before failing

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] No new test required since it is non-breaking changes and existing unit tests pass locally with my changes