### PR TITLE
Fix generate verifier command

### DIFF
--- a/packages/rust-verifier/src/main.rs
+++ b/packages/rust-verifier/src/main.rs
@@ -88,13 +88,13 @@ fn main() {
             );
 
             let proof = GrothBnProof::from_json_file(proof);
-            let public_inputs: PublicInputs<3> = PublicInputs::from_json_file(public_inputs);
+            let public_inputs = PublicInputs::from_json_file(public_inputs);
 
             let mut serialized_public_inputs = Vec::new();
             let mut serialized_proof = Vec::new();
 
             let writer = BufWriter::new(&mut serialized_public_inputs);
-            public_inputs.inputs.serialize_compressed(writer).unwrap();
+            public_inputs.serialize_compressed(writer).unwrap();
 
             let writer = BufWriter::new(&mut serialized_proof);
             proof.serialize_compressed(writer).unwrap();


### PR DESCRIPTION
**Description**


Fixes #265 where the generate-verifier-arguments in rust-verifier CLI supports public inputs of size 3 due to a hardcoded value in the PublicInputs struct. The changes modify the PublicInputs struct to use a dynamic Vec<GrothFp> instead of a fixed-size array [GrothFp; N], allowing the command to handle public inputs of any size. 




 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 This change requires a documentation update

Checklist:
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
