### PR TITLE
fix(helpers): replace Buffer with TextDecoder in DKIM sanitizer for cross-env compatibility

### DIFF
--- a/packages/helpers/src/dkim/sanitizers.ts
+++ b/packages/helpers/src/dkim/sanitizers.ts
@@ -53,7 +53,7 @@ function insert13Before10(email: string): string {
     j++;
   }
 
-  return Buffer.from(ret.slice(0, j).buffer).toString();
+  return new TextDecoder().decode(ret.slice(0, j));
 }
 
 // Replace `=09` with `\t` in email


### PR DESCRIPTION
Switched Buffer.from(...).toString() to new TextDecoder().decode(...) in insert13Before10.
Removes Node-only Buffer usage and resolves TS linter error “Cannot find name 'Buffer'”.
Improves portability (works in browsers and Node) without changing behavior.