### PR TITLE
fix: type cast in `poseidonLarge`

### DIFF
--- a/packages/helpers/src/hash.ts
+++ b/packages/helpers/src/hash.ts
@@ -6,7 +6,7 @@ export async function poseidonLarge(input: bigint, numChunks: number, bitsPerChu
   const pubkeyChunked = bigIntToChunkedBytes(input, bitsPerChunk, numChunks);
   const hash = poseidon(pubkeyChunked);
 
-  return poseidon.F.toObject(hash) as Promise<bigint>;
+  return poseidon.F.toObject(hash);
 }
 
 /**


### PR DESCRIPTION
## Description

removed unnecessary `as Promise<bigint>`-`poseidon.F.toObject` already returns a bigint, and async handles the promise automatically.


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have discussed with the team prior to submitting this PR
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
