### PR TITLE
fix: SHA hashing with Uint8Array support

### DIFF
--- a/packages/helpers/src/sha-utils.ts
+++ b/packages/helpers/src/sha-utils.ts
@@ -1,4 +1,4 @@
-import * as CryptoJS from 'crypto';
+import { createHash } from 'crypto';
 import { assert, int64toBytes, int8toBytes, mergeUInt8Arrays } from './binary-format';
 import { Hash } from './lib/fast-sha256';
 
@@ -76,7 +76,7 @@ export function generatePartialSHA({
 }
 
 export function shaHash(str: Uint8Array) {
-  return CryptoJS.createHash('sha256').update(str).digest();
+  return createHash('sha256').update(Buffer.from(str)).digest();
 }
 
 export function partialSha(msg: Uint8Array, msgLen: number): Uint8Array {


### PR DESCRIPTION
## Description

updated the script to correctly handle `Uint8Array` inputs.

* replaced the `crypto` import and `CryptoJS.createHash` usage with Node.js standard `createHash`
* `shaHash` now works correctly with `Uint8Array`
* no other changes to the code

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have discussed with the team prior to submitting this PR
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
