### PR TITLE
test(circuits): cover regex reveal max length boundary

### DIFF
--- a/packages/circuits/tests/select-regex-reveal.test.ts
+++ b/packages/circuits/tests/select-regex-reveal.test.ts
@@ -112,4 +112,29 @@ describe("Select Regex Reveal", () => {
 
         expect.assertions(1);
     });
+
+    it("should fail when revealed data continues after max reveal length", async function () {
+        let input = new Array(34).fill(0);
+        const startIndex = 10;
+        const maxRevealLen = 8;
+        const revealed = Array.from({ length: maxRevealLen }, () =>
+            "a".charCodeAt(0)
+        );
+        for (let i = 0; i < revealed.length; i++) {
+            input[startIndex + i] = revealed[i];
+        }
+        input[startIndex + maxRevealLen] = "m".charCodeAt(0);
+
+        try {
+            const witness = await circuit.calculateWitness({
+                in: input,
+                startIndex: startIndex,
+            });
+            await circuit.checkConstraints(witness);
+        } catch (error) {
+            expect((error as Error).message).toMatch("Assert Failed");
+        }
+
+        expect.assertions(1);
+    });
 });


### PR DESCRIPTION
## Description

Adds a focused regression test for `SelectRegexReveal` so an input with exactly `maxRevealLen` revealed bytes plus one additional non-zero byte is rejected. This locks in the mitigation discussed in #70, where a longer address could otherwise be truncated at the reveal limit and spoof a shorter address.

Fixes #70.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have discussed with the team prior to submitting this PR
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Verification

- Not run: `yarn install --immutable` cannot complete on this Windows workspace because `@zk-email/zk-regex-circom` contains a dependency path with `?` (`circuits/common/from_addr?.json`), which Windows rejects during `node_modules` linking.
- Before further dependency work, checked repo package manifests for install/prepare lifecycle hooks; no package-level `preinstall`, `install`, `postinstall`, or `prepare` hooks were present, and the lockfile Git dependencies are pinned to specific commits.
- GitHub checks on the pushed branch are passing: GitGuardian Security Checks, Socket Security Project Report, Socket Security Pull Request Alerts, and CodeRabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage validating proper error handling when revealed data exceeds maximum length constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkemail/zk-email-verify/pull/315)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->