### PR TITLE
fix(scripts): support DKIM registry artifact-only runs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,13 +2,14 @@
 
 ### 1. update-dkim-registry
 
-This will fetch DKIM keys for popular domains, save the result to json files, and update contracts.
+This will fetch DKIM keys for popular domains, save the result to json files, and update contracts by default.
 
 ENVS:
 ```
 RPC_URL= #rpc url of the chain
 DKIM_REGISTRY=  #address of the token registry
 PRIVATE_KEY=  #private key of the wallet
+UPDATE_DKIM_REGISTRY_ONCHAIN=false #optional: fetch, split, and hash keys without sending registry transactions
 ```
 
 Run
@@ -16,3 +17,10 @@ Run
 ```bash
 yarn update-dkim-registry
 ```
+
+To generate only the local key artifacts, run with `UPDATE_DKIM_REGISTRY_ONCHAIN=false`.
+This writes:
+
+- `dkim-keys.json`
+- `dkim-keys-chunked.json`
+- `dkim-keys-hashed.json`

--- a/scripts/dkim/update-dkim-registry.ts
+++ b/scripts/dkim/update-dkim-registry.ts
@@ -3,7 +3,7 @@ import { buildPoseidon } from "circomlibjs";
 import dns from "dns";
 import path from "path";
 import forge from "node-forge";
-import { bigIntToChunkedBytes } from "@zk-email/helpers/src/binaryFormat";
+import { bigIntToChunkedBytes } from "@zk-email/helpers/src/binary-format";
 const fs = require("fs");
 import { abi } from "../abis/DKIMRegistry.json";
 import { poseidonLarge } from "@zk-email/helpers/src/hash";
@@ -14,9 +14,9 @@ async function updateContract(domain: string, pubkeyHashes: string[]) {
     return;
   }
 
-  if (!process.env.PRIVATE_KEY) throw new Error("Env private key found");
-  if (!process.env.RPC_URL) throw new Error("Env RPC URL found");
-  if (!process.env.DKIM_REGISTRY) throw new Error("Env DKIM_REGISTRY found");
+  if (!process.env.PRIVATE_KEY) throw new Error("Env PRIVATE_KEY not found");
+  if (!process.env.RPC_URL) throw new Error("Env RPC_URL not found");
+  if (!process.env.DKIM_REGISTRY) throw new Error("Env DKIM_REGISTRY not found");
 
   const provider = new JsonRpcProvider(process.env.RPC_URL);
   const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
@@ -213,9 +213,11 @@ async function getDKIMPublicKeysForDomains(filename: string) {
 async function updateDKIMRegistry({
   domainListFile,
   writeToFile,
+  updateContractOnChain,
 }: {
   domainListFile: string;
   writeToFile: boolean;
+  updateContractOnChain: boolean;
 }) {
   function _writeToFile(filename: string, data: object) {
     if (!writeToFile) return;
@@ -266,6 +268,11 @@ async function updateDKIMRegistry({
   }
   _writeToFile("dkim-keys-hashed.json", domainHashedPubKeyMap);
 
+  if (!updateContractOnChain) {
+    console.log("Skipping on-chain DKIM registry update.");
+    return;
+  }
+
   // Update Mailserver contract with found keys
   for (let domain of Object.keys(domainHashedPubKeyMap)) {
     await updateContract(domain, domainHashedPubKeyMap[domain]);
@@ -275,4 +282,5 @@ async function updateDKIMRegistry({
 updateDKIMRegistry({
   domainListFile: path.join(__dirname, "domains.txt"),
   writeToFile: true,
+  updateContractOnChain: process.env.UPDATE_DKIM_REGISTRY_ONCHAIN !== "false",
 });


### PR DESCRIPTION
## Description

Makes the existing DKIM registry update script usable as a fetch/split/hash artifact generator without requiring contract credentials or sending registry transactions.

This is a scoped step toward #66: the script already discovers DKIM TXT records, extracts public keys, chunks them for the circuit, and writes Poseidon hashes. This PR fixes the stale helper import and documents `UPDATE_DKIM_REGISTRY_ONCHAIN=false` so maintainers can run the local artifact-generation path independently from on-chain updates.

Refs #66.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have discussed with the team prior to submitting this PR
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Verification

- Not run: `yarn install --immutable` cannot complete on this Windows workspace because `@zk-email/zk-regex-circom` contains a dependency path with `?` (`circuits/common/from_addr?.json`), which Windows rejects during `node_modules` linking.
- No new dependencies or downloads were added. Before prior dependency work in this checkout, repo package manifests were checked for install/prepare lifecycle hooks; no package-level `preinstall`, `install`, `postinstall`, or `prepare` hooks were present, and the lockfile Git dependencies are pinned to specific commits.