### PR TITLE
fix: remove helper console output

### DIFF
--- a/packages/helpers/src/binary-format.ts
+++ b/packages/helpers/src/binary-format.ts
@@ -207,5 +207,3 @@ export function packBytesIntoNBytes(messagePaddedRaw: Uint8Array | string, n = 7
   return output;
 }
 // Usage: let in_padded_n_bytes = packBytesIntoNBytes(messagePadded, 7).map((x) => x.toString()); // Packed into 7 byte signals
-
-// console.log(packedNBytesToString([30680772461461504n, 129074054722665n, 30794022159122432n, 30803244232763745n]));

--- a/packages/helpers/src/chunked-zkey.ts
+++ b/packages/helpers/src/chunked-zkey.ts
@@ -23,7 +23,6 @@ async function storeArrayBuffer(keyname: string, buffer: ArrayBuffer) {
 
 async function downloadWithRetries(link: string, downloadAttempts: number) {
   for (let i = 1; i <= downloadAttempts; i++) {
-    console.log(`download attempt ${i} for ${link}`);
     const response = await fetch(link, { method: 'GET' });
     if (response.status === 200) {
       return response;
@@ -48,12 +47,9 @@ export async function downloadFromFilename(baseUrl: string, filename: string, co
     const zkeyUncompressed = await uncompressGz(zkeyBuff);
     const rawFilename = filename.replace(zkeyExtensionRegEx, ''); // replace .gz with ""
     // store the uncompressed data
-    console.log('storing file in localforage', rawFilename);
     await storeArrayBuffer(rawFilename, zkeyUncompressed);
-    console.log('stored file in localforage', rawFilename);
     // await localforage.setItem(filename, zkeyBuff);
   }
-  console.log(`Storage of ${filename} successful!`);
 }
 
 export async function downloadProofFiles(baseUrl: string, circuitName: string, onFileDownloaded: () => void) {
@@ -63,26 +59,21 @@ export async function downloadProofFiles(baseUrl: string, circuitName: string, o
     // const itemCompressed = await localforage.getItem(targzFilename);
     const item = await localforage.getItem(`${circuitName}.zkey${c}`);
     if (item) {
-      console.log(`${circuitName}.zkey${c}${item ? '' : zkeyExtension} already found in localforage!`);
       onFileDownloaded();
       continue;
     }
     filePromises.push(downloadFromFilename(baseUrl, targzFilename, true).then(() => onFileDownloaded()));
   }
-  console.log(filePromises);
   await Promise.all(filePromises);
 }
 
 export async function generateProof(input: any, baseUrl: string, circuitName: string) {
   // TODO: figure out how to generate this s.t. it passes build
-  console.log('generating proof for input');
-  console.log(input);
   const { proof, publicSignals } = await snarkjs.groth16.fullProve(
     input,
     `${baseUrl}${circuitName}.wasm`,
     `${circuitName}.zkey`,
   );
-  console.log(`Generated proof ${JSON.stringify(proof)}`);
 
   return {
     proof,
@@ -91,15 +82,10 @@ export async function generateProof(input: any, baseUrl: string, circuitName: st
 }
 
 export async function verifyProof(proof: any, publicSignals: any, baseUrl: string, circuitName: string) {
-  console.log('PROOF', proof);
-  console.log('PUBLIC SIGNALS', publicSignals);
-
   const response = await downloadWithRetries(`${baseUrl}${circuitName}.vkey.json`, 3);
   const vkey = await response.json();
-  console.log('vkey', vkey);
 
   const proofVerified = await snarkjs.groth16.verify(vkey, publicSignals, proof);
-  console.log('proofV', proofVerified);
 
   return proofVerified;
 }

--- a/packages/helpers/src/dkim/dns-over-http.ts
+++ b/packages/helpers/src/dkim/dns-over-http.ts
@@ -124,11 +124,6 @@ export async function resolveDNSHTTP(name: string, type: string) {
   try {
     const cloudflareResult = await DoH.resolveDKIMPublicKey(name, DoHServer.Cloudflare);
 
-    // If we have both results, log if there's a mismatch
-    if (dkimRecord && cloudflareResult && dkimRecord !== cloudflareResult) {
-      console.warn('DKIM record mismatch between Google and Cloudflare! Using Google result.');
-    }
-
     // If we don't have a Google result, use Cloudflare's result
     if (!dkimRecord && cloudflareResult) {
       const regex = /p=([^;]*)/;

--- a/packages/helpers/src/dkim/index.ts
+++ b/packages/helpers/src/dkim/index.ts
@@ -59,7 +59,6 @@ export async function verifyDKIMSignature(
     const passed = results.find((r) => r.result.status.result === 'pass');
 
     if (passed) {
-      console.log(`DKIM: Verification passed after applying sanitization "${passed.sanitizer}"`);
       dkimResult = passed.result;
       appliedSanitization = passed.sanitizer;
     }

--- a/packages/helpers/src/lib/mailauth/body/relaxed.ts
+++ b/packages/helpers/src/lib/mailauth/body/relaxed.ts
@@ -293,6 +293,4 @@ for (let byte of getBody(s)) {
     k.update(Buffer.from([byte]));
 }
 
-console.error(k.digest('base64'));
-console.error(k.byteLength, k.bodyHashedBytes);
 */

--- a/packages/helpers/src/lib/mailauth/tools.ts
+++ b/packages/helpers/src/lib/mailauth/tools.ts
@@ -39,7 +39,6 @@ export const writeToStream = async (
   return new Promise((resolve, reject) => {
     if (typeof input?.on === 'function') {
       // pipe as stream
-      console.log('pipe');
       input.pipe(stream);
       input.on('error', reject);
     } else {

--- a/packages/helpers/tests/no-console.test.ts
+++ b/packages/helpers/tests/no-console.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+import * as ts from 'typescript';
+
+const helpersSrcRoot = path.resolve(__dirname, '..', 'src');
+const blockedConsoleMethods = new Set(['debug', 'error', 'info', 'log', 'trace', 'warn']);
+
+function collectTypeScriptFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return collectTypeScriptFiles(entryPath);
+    }
+    return entry.isFile() && entry.name.endsWith('.ts') ? [entryPath] : [];
+  });
+}
+
+describe('helper package console output', () => {
+  it('does not call console methods directly from library source files', () => {
+    const offenders: string[] = [];
+
+    for (const filePath of collectTypeScriptFiles(helpersSrcRoot)) {
+      const sourceText = fs.readFileSync(filePath, 'utf8');
+      const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
+
+      const visit = (node: ts.Node) => {
+        if (ts.isCallExpression(node)) {
+          const expression = node.expression;
+          if (
+            ts.isPropertyAccessExpression(expression) &&
+            expression.expression.getText(sourceFile) === 'console' &&
+            blockedConsoleMethods.has(expression.name.text)
+          ) {
+            const location = sourceFile.getLineAndCharacterOfPosition(expression.getStart(sourceFile));
+            const relativePath = path.relative(helpersSrcRoot, filePath).replace(/\\/g, '/');
+            offenders.push(
+              `${relativePath}:${location.line + 1}:${location.character + 1} console.${expression.name.text}`,
+            );
+          }
+        }
+
+        ts.forEachChild(node, visit);
+      };
+
+      ts.forEachChild(sourceFile, visit);
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
This PR removes direct console output from the helpers library so downstream apps can use it without unsolicited production logs. The changed surface is limited to helper runtime files plus one regression test.

Fixes #262.

| Area | Change | Evidence |
| --- | --- | --- |
| Helper runtime output | Removed active `console.log`/`console.warn` calls from zkey download/proof helpers, DKIM sanitization, DNS-over-HTTP fallback handling, and mailauth stream writes. | `rg -n console\\.(log|debug|info|warn|error|trace) packages/helpers/src --glob *.ts` returns no matches. |
| Regression coverage | Added an AST-based Jest test that scans `packages/helpers/src` for real `console.*` call expressions, while ignoring comments. | `npx jest tests/no-console.test.ts tests/chunked-zkey.test.ts tests/dkim.test.ts --runInBand` passed: 3 suites, 17 tests. |
| Formatting and diff hygiene | Normalized the touched files with Prettier and checked whitespace. | `npx prettier --check ...` passed; `git diff --check` passed. |

Validation run locally:

```text
npx jest tests/no-console.test.ts tests/chunked-zkey.test.ts tests/dkim.test.ts --runInBand
PASS tests/dkim.test.ts
PASS tests/chunked-zkey.test.ts
PASS tests/no-console.test.ts
Test Suites: 3 passed, 3 total
Tests: 17 passed, 17 total

npx prettier --check src/chunked-zkey.ts src/dkim/index.ts src/dkim/dns-over-http.ts src/lib/mailauth/tools.ts src/binary-format.ts src/lib/mailauth/body/relaxed.ts tests/no-console.test.ts
All matched files use Prettier code style!

git diff --check
clean
```

I also tried the root Yarn install path, but it is currently blocked on Windows while linking `@zk-email/zk-regex-circom` because that package contains `circuits/common/from_addr?.json`. A package-level `npm run build` under `packages/helpers` was therefore not a clean verification signal in this workspace; with npm-only helper deps it stops on the existing missing `circomlibjs` declaration in `src/hash.ts`.

This PR deliberately leaves script and test-only console output outside `packages/helpers/src` untouched.