### PR TITLE
fix: correct spelling in test files and comments

### DIFF
--- a/packages/circuits/tests/email-verifier-no-body.test.ts
+++ b/packages/circuits/tests/email-verifier-no-body.test.ts
@@ -32,7 +32,7 @@ describe("EmailVerifier : Without body check", () => {
     });
 
     it("should verify email when ignore_body_hash_check is true", async function () {
-        // The result wont have shaPrecomputeSelector, maxHeadersLength, maxBodyLength, ignoreBodyHashCheck
+        // The result won't have shaPrecomputeSelector, maxHeadersLength, maxBodyLength, ignoreBodyHashCheck
         const emailVerifierInputs = generateEmailVerifierInputsFromDKIMResult(
             dkimResult,
             {

--- a/packages/helpers/src/binary-format.ts
+++ b/packages/helpers/src/binary-format.ts
@@ -10,7 +10,7 @@ export function stringToBytes(str: string) {
   const toReturn = Uint8Array.from(str, (x) => x.charCodeAt(0));
   //   const buf = Buffer.from(str, "utf8");
   return toReturn;
-  // TODO: Check encoding mismatch if the proof doesnt work
+  // TODO: Check encoding mismatch if the proof doesn't work
   // Note that our custom encoding function maps (239, 191, 189) -> (253)
   // Note that our custom encoding function maps (207, 181) -> (245)
   // throw Error(

--- a/packages/helpers/tests/dkim.test.ts
+++ b/packages/helpers/tests/dkim.test.ts
@@ -62,7 +62,7 @@ describe('DKIM signature verification', () => {
     // Should pass with default domain
     await verifyDKIMSignature(email);
 
-    // Should fail because the email wont have a DKIM signature with the overridden domain
+    // Should fail because the email won't have a DKIM signature with the overridden domain
     // Can be replaced with a better test email where signer is actually
     // different from From domain and the below check pass.
     expect.assertions(1);


### PR DESCRIPTION
## Description
Fixed spelling errors in test files and comments.

⚠️ **Note:** Comment and test changes only. No functional code modified.

## Changes
- Fix 'wont' → 'won't'
- Fix 'doesnt' → 'doesn't'

## Files Modified
- packages/helpers/tests/dkim.test.ts
- packages/helpers/src/binary-format.ts
- packages/circuits/tests/email-verifier-no-body.test.ts

## Impact
- Test comment clarity improvement only
- No functional changes to ZK email verification logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected and clarified code comments across test files and helper utilities for improved code documentation clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkemail/zk-email-verify/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->