### PR TITLE
fix: use userland punycode in helpers

### DIFF
--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -22,6 +22,7 @@
     "localforage": "^1.10.0",
     "node-forge": "^1.3.1",
     "pako": "^2.1.0",
+    "punycode": "^2.3.1",
     "psl": "^1.9.0",
     "snarkjs": "https://github.com/sampritipanda/snarkjs.git#fef81fc51d17a734637555c6edbd585ecda02d9e"
   },

--- a/packages/helpers/src/lib/mailauth/tools.ts
+++ b/packages/helpers/src/lib/mailauth/tools.ts
@@ -4,7 +4,7 @@ import libmime from 'libmime';
 import psl from 'psl';
 import { setImmediate } from 'timers';
 import { pki } from 'node-forge';
-import punycode from 'punycode';
+import punycode from 'punycode/';
 import crypto, { KeyObject } from 'crypto';
 import parseDkimHeaders from './parse-dkim-headers';
 import { DkimVerifier } from './dkim-verifier';

--- a/packages/helpers/src/types/punycode-slash.d.ts
+++ b/packages/helpers/src/types/punycode-slash.d.ts
@@ -1,0 +1,4 @@
+declare module 'punycode/' {
+  const punycode: typeof import('punycode');
+  export = punycode;
+}

--- a/packages/helpers/tests/punycode.test.ts
+++ b/packages/helpers/tests/punycode.test.ts
@@ -14,11 +14,14 @@ describe('mailauth punycode dependency', () => {
     const warningListener = (warning: Error & { code?: string }) => warnings.push(warning.code ?? '');
 
     process.on('warning', warningListener);
-    jest.isolateModules(() => {
-      require('../src/lib/mailauth/tools');
-    });
-    await new Promise((resolve) => setImmediate(resolve));
-    process.off('warning', warningListener);
+    try {
+      jest.isolateModules(() => {
+        require('../src/lib/mailauth/tools');
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+    } finally {
+      process.off('warning', warningListener);
+    }
 
     expect(warnings).not.toContain('DEP0040');
   });

--- a/packages/helpers/tests/punycode.test.ts
+++ b/packages/helpers/tests/punycode.test.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('mailauth punycode dependency', () => {
+  const toolsSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'lib', 'mailauth', 'tools.ts'), 'utf8');
+  const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+
+  it('uses the userland punycode package instead of the deprecated Node core module', async () => {
+    expect(toolsSource).not.toMatch(/from ['"](?:node:)?punycode['"]/);
+    expect(toolsSource).toMatch(/from ['"]punycode\/['"]/);
+    expect(packageJson.dependencies).toHaveProperty('punycode');
+
+    const warnings: string[] = [];
+    const warningListener = (warning: Error & { code?: string }) => warnings.push(warning.code ?? '');
+
+    process.on('warning', warningListener);
+    jest.isolateModules(() => {
+      require('../src/lib/mailauth/tools');
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    process.off('warning', warningListener);
+
+    expect(warnings).not.toContain('DEP0040');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2771,6 +2771,7 @@ __metadata:
     msw: ^1.2.2
     node-forge: ^1.3.1
     pako: ^2.1.0
+    punycode: ^2.3.1
     prettier: ^3.3.3
     psl: ^1.9.0
     snarkjs: "https://github.com/sampritipanda/snarkjs.git#fef81fc51d17a734637555c6edbd585ecda02d9e"


### PR DESCRIPTION
## Description

Fixes #205.

This updates the helpers mailauth tools to import the npm/userland `punycode` package via `punycode/` instead of Node's deprecated core `punycode` module. It also adds `punycode` as an explicit helpers dependency and includes a focused regression test that checks both the import path and that loading `mailauth/tools` does not emit `DEP0040` on modern Node.

`psl` is already resolved to `1.15.0` in the existing Yarn lockfile, and a local Node 24 check did not emit `DEP0040` when requiring `psl`.

## Validation

- `npx.cmd jest tests/punycode.test.ts --runInBand`
- `npx.cmd prettier --check src/lib/mailauth/tools.ts src/types/punycode-slash.d.ts tests/punycode.test.ts package.json`
- `git diff --check`
- `node -e "let warnings=[];process.on('warning',w=>warnings.push(w.code));require('punycode/');require('psl');setImmediate(()=>{if(warnings.includes('DEP0040')){console.error('DEP0040 emitted');process.exit(1)}console.log('no DEP0040 for punycode/ plus psl')})"`

`npm.cmd run build` currently stops on the existing missing declaration for `circomlibjs` in `src/hash.ts`; after adding the local `punycode/` declaration, the build no longer reports a `punycode/` type error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility by switching from deprecated core `punycode` usage to the supported `punycode` package, reducing deprecation warnings.
  * Updated module resolution to support `punycode/` imports consistently.
* **Documentation**
  * Added TypeScript declaration support for `punycode/` so existing helper imports remain correctly typed.
* **Tests**
  * Added Jest coverage to ensure the helpers use the external `punycode` package and don’t emit related deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->