### PR TITLE
fix: correct RevealSubstring LessThan bit widths

### DIFF
--- a/packages/circuits/helpers/reveal-substring.circom
+++ b/packages/circuits/helpers/reveal-substring.circom
@@ -20,16 +20,16 @@ template RevealSubstring(maxLength, maxSubstringLength, shouldCheckUniqueness) {
     signal output substring[maxSubstringLength];
 
     // Substring start index should be less than maxLength
-    signal isSubstringStartIndexValid <== LessThan(log2Ceil(maxLength))([substringStartIndex, maxLength]);
+    signal isSubstringStartIndexValid <== LessThan(log2Ceil(maxLength + 1))([substringStartIndex, maxLength]);
     isSubstringStartIndexValid === 1;
 
     // Substring length should be less than maxSubstringLength + 1
-    signal isSubstringLengthValid <== LessThan(log2Ceil(maxSubstringLength + 1))([substringLength, maxSubstringLength + 1]);
+    signal isSubstringLengthValid <== LessThan(log2Ceil(maxSubstringLength + 2))([substringLength, maxSubstringLength + 1]);
     isSubstringLengthValid === 1;
 
     // substring index + substring length should be less than maxLength + 1
     signal sum <== substringStartIndex + substringLength;
-    signal isSumValid <== LessThan(log2Ceil(maxLength + 1))([sum, maxLength + 1]);
+    signal isSumValid <== LessThan(log2Ceil(maxLength + 2))([sum, maxLength + 1]);
     isSumValid === 1;
 
     // Extract the substring

--- a/packages/circuits/tests/reveal-substring-bit-width.test.ts
+++ b/packages/circuits/tests/reveal-substring-bit-width.test.ts
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+
+describe("RevealSubstring LessThan bit widths", () => {
+  it("allocates one extra value for exclusive upper-bound constants", () => {
+    const source = fs.readFileSync(
+      path.join(__dirname, "../helpers/reveal-substring.circom"),
+      "utf8",
+    );
+    const compactSource = source.replace(/\s+/g, "");
+
+    expect(compactSource).toContain(
+      "LessThan(log2Ceil(maxLength+1))([substringStartIndex,maxLength])",
+    );
+    expect(compactSource).toContain(
+      "LessThan(log2Ceil(maxSubstringLength+2))([substringLength,maxSubstringLength+1])",
+    );
+    expect(compactSource).toContain(
+      "LessThan(log2Ceil(maxLength+2))([sum,maxLength+1])",
+    );
+  });
+});


### PR DESCRIPTION
## Description

Fixes #289.

`LessThan(n)` requires both inputs to fit in `[0, 2^n - 1]`. `RevealSubstring` compared dynamic signals against exclusive upper-bound constants such as `maxLength`, `maxSubstringLength + 1`, and `maxLength + 1`, but computed `n` from the constant itself. When one of those constants is a power of two, the constant cannot fit in the selected bit width.

This PR updates the three `LessThan` bit-width calculations so each exclusive upper-bound constant has one representable value of headroom:

- `substringStartIndex < maxLength` uses `log2Ceil(maxLength + 1)`
- `substringLength < maxSubstringLength + 1` uses `log2Ceil(maxSubstringLength + 2)`
- `substringStartIndex + substringLength < maxLength + 1` uses `log2Ceil(maxLength + 2)`

It also adds a focused regression test that guards those formulas.

## Validation

- `npx.cmd jest tests/reveal-substring-bit-width.test.ts --runInBand`
- `npx.cmd prettier --check tests/reveal-substring-bit-width.test.ts`
- `git diff --check`

I also ran `npx.cmd jest tests/reveal-substring.test.ts --runInBand --detectOpenHandles --forceExit --verbose`, but this local Windows environment does not have `circom` in PATH, so the existing circuit execution tests stop at `circom --version` before running assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened boundary checks for substring validation to handle edge cases more accurately when start positions, lengths, and combined ranges are near their limits.
  * Kept the substring extraction and optional uniqueness behavior unchanged.

* **Tests**
  * Added coverage to verify the updated boundary-check logic for substring-related constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->