### PR TITLE
Remove paid contributor program references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,11 +35,8 @@ Our issues are categorized by labels to help you identify tasks that might inter
 
 Feel free to filter issues by these labels to find what suits your skills and interests.
 
-## Incentives for Contributions
-We are excited to announce that we will award a $50-$200 bounty for every Pull Request (PR) that is successfully merged and addresses an open issue in our repository. Should there be any oversight on our part regarding the bounty, please feel free to send us a direct message as a reminder.
-
 ## Project Ideas
-We have curated a list of exciting project ideas that we believe would significantly enhance the functionality and user experience of our platform. We encourage contributors to explore these ideas and bring them to fruition. We will give a grant for any successful implementation.
+We have curated a list of exciting project ideas that we believe would significantly enhance the functionality and user experience of our platform. We encourage contributors to explore these ideas and bring them to fruition.
 
 
 | Title | Description |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Moreover, for those interested in creating the Twitter circuit from scratch, our
   - Audit from [yAcademy](https://yacademy.dev/) - [Report](/audits/yacademy-audit.pdf).
 
 ## Contributors 💡
-For each pull request that successfully merges and addresses an [open issue](https://github.com/zkemail/zk-email-verify/issues), we offer a $50 reward. Feel free to email support@zk.email to let us know. To learn more about how you can contribute to this project, please consult our [Contributing Guide](CONTRIBUTING.md). Thank you to all of our existing contributors!
+To learn more about how you can contribute to this project, please consult our [Contributing Guide](CONTRIBUTING.md). Thank you to all of our existing contributors!
 
 ## Licensing
 Everything we write is MIT-licensed. Note that circom and circomlib is GPL. Broadly we are pro permissive open source usage with attribution! We hope that those who derive profit from this, contribute that money altruistically back to this technology and open source public goods.


### PR DESCRIPTION
## Human intent

- Remove paid contributor program references from the personal ideas repository and zkEmail.

## Changes

Remove contributor payout offers, project grant promises, and related promotional wording wherever present in this repository. Preserve project ideas, contribution instructions, and contributor credits.

## Validation

- Reviewed the diff and searched tracked documentation for remaining payment offers.
- `git diff --check` passed.
- Documentation-only change; no runtime code changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the contribution guide with a “Project Ideas” section and retained the existing project-ideas description.
  - Revised the README’s Contributors section to direct contributors to the Contributing Guide.
  - Removed references to monetary rewards for pull requests addressing open issues.
  - Removed the instruction to contact support by email regarding contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->